### PR TITLE
Add module for SDC host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore Terraform state files
+*.tfstate
+*.tfstate.backup
+
+# Ignore Terraform variable files
+terraform.tfvars
+# Ignore .terraform 
+.terraform/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+docs:
+	# install via
+	# go install github.com/terraform-docs/terraform-docs@v0.17.0
+	terraform-docs markdown table --output-file README.md --output-mode inject modules/sdc_host_linux/
+	terraform-docs markdown table --output-file README.md --output-mode inject examples/sdc_host_linux/
+	terraform-docs markdown table --output-file README.md --output-mode inject modules/user/
+	terraform-docs markdown table --output-file README.md --output-mode inject examples/user/

--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ The Terraform Modules for Dell PowerFlex is released and licensed under the MPL-
 
 ## List of Submodules in Terraform Modules for Dell PowerFlex
   * [User](modules/user/README.md)
+  * [SDC](modules/sdc_host_linux/README.md)

--- a/examples/sdc_host_linux/README.md
+++ b/examples/sdc_host_linux/README.md
@@ -1,0 +1,95 @@
+<!--
+Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Mozilla Public License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://mozilla.org/MPL/2.0/
+
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# SDC Host Module
+
+This Terraform module installs the SDC package on a remote Linux host using the `powerflex_sdc_host` resource.
+
+## Example inputs
+
+terraform.tfvars
+```hcl
+remote_host={
+    user = "root"
+    private_key = ""
+    certificate = ""
+    password = "password"
+    }
+
+
+ip="1.2.11.10"
+scini_url="http://example.com/sw_dev/Artifacts/Build-All-Ubuntu22.04/3.6.700.103/release/5.15.0-112-generic"
+versions={
+    pflex = "3.6.700.103"
+    kernel = "5.15.0-112-generic"
+}
+
+sdc_pkg = {
+    url = "http://example.com/release/SIGNED/EMC-ScaleIO-sdc-3.6-700.103.Ubuntu.22.04.x86_64.tar"
+    local_pkg = "EMC-ScaleIO-sdc-3.6-700.103.Ubuntu.22.04.x86_64.tar"
+    local_dir = "/tmp"
+    pkg_name = "EMC-ScaleIO-sdc-3.6-700.103.Ubuntu.22.04.x86_64.tar"
+    remote_pkg_name = "emc-sdc-package.tar"
+    remote_dir = "/tmp"
+    remote_file = "EMC-ScaleIO-sdc-3.6-700.103.Ubuntu.22.04.x86_64.tar"
+    use_remote_path = false
+}
+
+powerflex_config = {
+    username = "admin"
+    endpoint = "https://1.2.3.4:443"
+    password = "Password" 
+}
+```
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform apply
+```
+
+
+After successful operation of above commands, to remove deployment, you need to execute:
+
+```bash
+terraform destroy 
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_sdc_host_linux"></a> [sdc\_host\_linux](#module\_sdc\_host\_linux) | ../../modules/sdc_host_linux | n/a |
+
+## Resources
+
+No resources.
+
+
+<!-- END_TF_DOCS -->

--- a/examples/sdc_host_linux/main.tf
+++ b/examples/sdc_host_linux/main.tf
@@ -1,0 +1,34 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+
+##############
+# PowerFlex SDC
+##############
+
+module "sdchostlinux" {
+  # Here source points to the sdc_host_linux submodule in the modules folder. You can change the value to point it according to your usecase. 
+  source = "../../modules/sdc_host_linux"
+
+  versions = var.versions
+  ip = var.ip
+  remote_host = var.remote_host
+  scini_url = var.scini_url
+  sdc_pkg = var.sdc_pkg
+  mdm_ips = var.mdm_ips
+}
+

--- a/examples/sdc_host_linux/provider.tf
+++ b/examples/sdc_host_linux/provider.tf
@@ -1,0 +1,17 @@
+terraform {
+   required_providers {
+     powerflex = {
+       version = ">=1.6.0"
+       source  = "registry.terraform.io/dell/powerflex"
+     }
+   }
+ }
+
+
+provider "powerflex" {
+  username = var.powerflex_config.username
+  password = var.powerflex_config.password
+  endpoint = var.powerflex_config.endpoint
+  insecure = true
+  timeout  = 120
+}

--- a/examples/sdc_host_linux/variables.tf
+++ b/examples/sdc_host_linux/variables.tf
@@ -1,0 +1,80 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+# This Terraform module installs the SDC package on a remote Linux host using the `powerflex_sdc_host` resource.
+
+# Define the input variables for the module
+variable "ip" {
+  type        = string
+  description = "Stores the IP address of the remote Linux host."
+}
+
+variable "remote_host" {
+  description = "Stores the SSH credentials for connecting to the remote Linux host."
+  type        = object({
+    # Define the `user` attribute of the `remote` variable.
+    user = string
+    # Define the ssh `private_key` file with path for the SDC login user
+    private_key = optional(string, "")
+    # Define the ssh `certificate` file path, issued to the SDC login user
+    certificate = optional(string, "")
+    password = optional(string)
+  })
+
+}
+
+variable "powerflex_config" {
+  description = "Stores the configuration for terraform PowerFlex provider."
+  type        = object({
+    # Define the attributes of the configuration for terraform PowerFlex provider.
+    username = string
+    endpoint = string
+    password = string
+  })
+}
+
+variable "mdm_ips" {
+  description = "all the mdms (either primary,secondary or virtual ips) in a comma separated list by cluster if unset will use the mdms of the cluster set in the provider block eg. ['10.10.10.5,10.10.10.6', '10.10.10.7,10.10.10.8']"
+  type        = list(string)
+  default = []
+}
+
+variable "scini_url" {
+  type        = string
+  description = "The URL where the SCINI module package is located."
+}
+
+variable "sdc_pkg" {
+  description = "configuration for SDC package like url to download package from, copy as local package or directory on remote server. One of local_dir or remote_dir will be used based on the variable use_remote_path"
+  type = object({
+    # examples "http://example.com/EMC-ScaleIO-sdc-3.6-700.103.Ubuntu.22.04.x86_64.tar", "ftp://username:password@ftpserver/path/to/file"
+    url = string
+    pkg_name = string
+    remote_pkg_name = optional(string)
+    local_dir = string
+    remote_dir = optional(string, "/tmp")
+    # use the SDC package on remote machine path (where SDC is deployed)
+    use_remote_path = bool
+  })
+}
+
+variable "versions" {
+  type = object({
+    pflex = string
+    kernel = string
+  })
+}

--- a/modules/sdc_host_linux/README.md
+++ b/modules/sdc_host_linux/README.md
@@ -1,0 +1,71 @@
+<!--
+Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Mozilla Public License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://mozilla.org/MPL/2.0/
+
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# SDC Host Module
+
+This Terraform module installs the SDC package on a remote Linux host using the `powerflex_sdc_host` resource.
+
+## Variables
+
+| Variable Name | Description |
+|---------------|-------------|
+| `ip` | Stores the IP address of the remote Linux host. |
+| `remote_host` | Stores the SSH credentials for connecting to the remote Linux host. |
+| `remote_host.user` | Stores the username for connecting to the remote Linux host. root will have all required privileges.|
+| `remote_host.private_key` | Stores the SSH private key for connecting to the remote Linux host. |
+| `remote_host.certificate` | Stores the SSH certificate for connecting to the remote Linux host. |
+| `remote_host.password` | Stores the password for connecting to the remote Linux host. |
+| `sdc_pkg` | Stores the SDC package information. |
+| `sdc_pkg.url` | Stores the URL to download the SDC package from. eg. "http://example.com/path/to/file", "ftp://username:password@ftpserver/path/to/file"|
+| `sdc_pkg.pkg_name` | Stores the name of the SDC package for local. |
+| `sdc_pkg.remote_pkg_name` | Stores the name of the SDC package for remote machine. It should be emc-sdc-package.(tar/rpm)|
+| `sdc_pkg.local_dir` | Stores the local directory where the SDC package will be downloaded. |
+| `sdc_pkg.remote_dir` | Stores the remote directory where the SDC package will be downloaded. Dir should be present. |
+| `sdc_pkg.use_remote_path` | Stores the flag to use the SDC package on a remote machine path or not. |
+| `versions` | Stores the kernel and PowerFlex versions. |
+| `scini_url` | The URL where the SCINI module package is located. |
+
+
+### Prerequisites
+
+SDC Host module can only be used with terraform provider PowerFlex v1.5.1 and above.
+
+For SELinux configration, refer to "Configure the SDC (scini) driver for SELinux" section in PowerFlex Install/Upgrade guide.
+
+
+
+## Usage
+
+```hcl
+module "sdc_host" {
+  source = "./modules/sdc_host_linux"
+
+  versions = var.versions
+  ip = var.ip
+  remote_host = var.remote_host
+  scini_url = var.scini_url
+  sdc_pkg = var.sdc_pkg
+}
+```
+
+Please refer the SDC Host example [here](../../examples/sdc_host_linux/main.tf)
+After providing proper values to all the attributes eg. using terraform.tfvars, then in that workspace, run
+
+```
+terraform init
+terraform apply
+```

--- a/modules/sdc_host_linux/main.tf
+++ b/modules/sdc_host_linux/main.tf
@@ -1,0 +1,233 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+
+# # Objectives
+# # 1. Copy of sdc package on either local or remote machine
+# # 2. downaload of scini
+# # 3. verification of kernel version.
+# # 4. SDC installation on Linux
+
+# # needed for ubuntu for installing kernel-specific scini module
+locals {
+  pflex_v = var.versions.pflex
+  kernel_v = var.versions.kernel
+}
+
+# # STEP 1 - download SDC artifacts from share to local machine
+
+
+locals {
+  use_remote_path = var.sdc_pkg.use_remote_path
+  share_url_scini = var.scini_url
+}
+resource terraform_data sdc_pkg_local {
+  #do if use_remote_path is false.
+  count = var.sdc_pkg.use_remote_path ? 0: 1
+  input = var.sdc_pkg
+  #One option is to download sdc on local drive and provide local path
+  provisioner "local-exec" {
+    command = "wget ${self.output.url} -P ${self.output.local_dir}"
+  }
+  provisioner "local-exec" {
+    when = destroy
+    command = "rm -r ${self.output.local_dir}/${self.output.pkg_name}"
+  }
+}
+
+# # STEP 2 - load remote login secrets
+# # ssh private key of SDC login user
+data local_sensitive_file ssh_key {
+   count = var.remote_host.private_key == "" ? 0 : 1
+   filename = var.remote_host.private_key
+}
+
+# # ssh certificate issued to SDC login user
+data local_sensitive_file ssh_cert {
+  count = var.remote_host.certificate == "" ? 0 : 1
+  filename = var.remote_host.certificate
+}
+
+#compare kernel version on remote machine with provided version
+resource "terraform_data" "compare_version" {
+
+   connection {
+    type = "ssh"
+    user = self.output.user.name
+    private_key = self.output.user.private_key
+    certificate = self.output.user.certificate
+    host = self.output.ip
+    password = self.output.user.password
+  }
+  input = {
+      user = {
+          name = var.remote_host.user
+          #user can use keys or userid/password. Make sure to copy the keys to remote server before using keys
+          private_key = var.remote_host.private_key == "" ? "" : data.local_sensitive_file.ssh_key[0].content
+          certificate = var.remote_host.certificate == "" ? "" : data.local_sensitive_file.ssh_cert[0].content
+          password = var.remote_host.password
+      }
+      sdc_pkg = var.sdc_pkg
+      kernel_v = local.kernel_v
+      ip  = var.ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cd ${self.output.sdc_pkg.remote_dir}",
+      "echo '#!/bin/bash' > compare_kernel.sh",
+      "echo 'current_version=$(uname -r)' >> compare_kernel.sh",
+      "echo 'compare_version=\"${self.output.kernel_v}\"' >> compare_kernel.sh",
+      "echo 'if [ \"$current_version\" != \"$compare_version\" ]; then' >> compare_kernel.sh",
+      "echo '  echo \"Kernel version $current_version does not match with specified $compare_version. Aborting...\"' >> compare_kernel.sh",
+      "echo '  exit 1' >> compare_kernel.sh",
+      "echo 'fi' >> compare_kernel.sh",
+      "chmod +x compare_kernel.sh",
+      "./compare_kernel.sh"
+     ]
+  }
+   provisioner "remote-exec" {
+    when = destroy
+    inline = [
+      "rm  ${self.output.sdc_pkg.remote_dir}/compare_kernel.sh"
+    ]
+  }
+
+}
+
+
+#copy SDC package on remote server
+resource terraform_data sdc_pkg_remote {
+  # perform if variable is true
+  count = local.use_remote_path ? 1 : 0
+  connection {
+    type = "ssh"
+    user = self.output.user.name
+    private_key = self.output.user.private_key
+    certificate = self.output.user.certificate
+    host = self.output.ip
+    password = self.output.user.password
+  }
+  input = {
+      user = {
+          name = var.remote_host.user
+          #user can use keys or userid/password. Make sure to copy the keys to remote server before using keys
+          private_key = var.remote_host.private_key == "" ? "" : data.local_sensitive_file.ssh_key[0].content
+          certificate = var.remote_host.certificate == "" ? "" : data.local_sensitive_file.ssh_cert[0].content
+          password = var.remote_host.password
+      }
+      sdc_pkg = var.sdc_pkg
+      ip = var.ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "wget ${self.output.sdc_pkg.url} -O ${self.output.sdc_pkg.remote_dir}/${self.output.sdc_pkg.remote_pkg_name}",
+    ]
+  }
+  provisioner "remote-exec" {
+    when = destroy
+    inline = [
+      "rm -rf ${self.output.sdc_pkg.remote_dir}/${self.output.sdc_pkg.remote_pkg_name}"
+    ]
+  }
+
+}
+
+
+
+
+# # STEP 3 - install pre-requisites (scini module)
+# # provisioner to install scini module on SDC
+resource "terraform_data" "linux_scini" {
+  connection {
+    type = "ssh"
+    user = self.output.user.name
+    private_key = self.output.user.private_key
+    certificate = self.output.user.certificate
+    host = self.output.ip
+    password = self.output.user.password
+  }
+  input = {
+      versions = {
+          pflex = local.pflex_v
+          kernel = local.kernel_v
+      }
+      user = {
+          name = var.remote_host.user
+          #user can use keys or userid/password. Make sure to copy the keys to remote server before using keys
+          private_key = var.remote_host.private_key == "" ? "" : data.local_sensitive_file.ssh_key[0].content
+          certificate = var.remote_host.certificate == "" ? "" : data.local_sensitive_file.ssh_cert[0].content
+          password = var.remote_host.password
+      }
+      ip = var.ip
+      scini_url = var.scini_url
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "mkdir -p /bin/emc/scaleio/scini_sync/driver_cache/Ubuntu/${local.pflex_v}/${local.kernel_v}",
+      "wget ${self.output.scini_url}/scini.ko -P /bin/emc/scaleio/scini_sync/driver_cache/Ubuntu/${local.pflex_v}/${local.kernel_v}",
+    ]
+  }
+  provisioner "remote-exec" {
+    when = destroy
+    inline = [
+      "rm -rf /bin/emc/scaleio/scini_sync/driver_cache/Ubuntu"
+    ]
+  }
+}
+
+# # STEP 4 - Install actual SDC
+# # SDC configuration
+ resource powerflex_sdc_host sdc_local_path {
+
+   count = local.use_remote_path ? 0 : 1 #deploy if variable is false
+   depends_on = [ terraform_data.linux_scini ]
+   ip = var.ip
+   remote = {
+     user = "root"
+     private_key = var.remote_host.private_key == "" ? null : data.local_sensitive_file.ssh_key[0].content
+     certificate = var.remote_host.certificate == "" ? null : data.local_sensitive_file.ssh_cert[0].content
+     password =  var.remote_host.password == "" ? null : var.remote_host.password
+     dir = terraform_data.sdc_pkg_local[0].output.remote_dir
+   }
+   os_family = "linux"
+   use_remote_path = local.use_remote_path
+   name = "sdc-${var.ip}"
+   package_path = "${terraform_data.sdc_pkg_local[0].output.local_dir}/${terraform_data.sdc_pkg_local[0].output.pkg_name}"
+   clusters_mdm_ips = var.mdm_ips
+ }
+
+ resource powerflex_sdc_host sdc_remote_path {
+   count = local.use_remote_path  ? 1 : 0 #deploy if variable is true
+   depends_on = [ terraform_data.linux_scini ]
+   ip = var.ip
+   remote = {
+     user = "root"
+     private_key = var.remote_host.private_key == "" ? null : data.local_sensitive_file.ssh_key[0].content
+     certificate = var.remote_host.certificate == "" ? null : data.local_sensitive_file.ssh_cert[0].content
+     password =  var.remote_host.password == "" ? null : var.remote_host.password
+     dir = terraform_data.sdc_pkg_remote[0].output.sdc_pkg.remote_dir
+   }
+   os_family = "linux"
+   use_remote_path = local.use_remote_path
+   name = "sdc-${var.ip}"
+   package_path = terraform_data.sdc_pkg_remote[0].output.sdc_pkg.pkg_name
+   clusters_mdm_ips = var.mdm_ips
+ }
+

--- a/modules/sdc_host_linux/provider.tf
+++ b/modules/sdc_host_linux/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+   required_providers {
+     powerflex = {
+       version = ">=1.6.0"
+       source  = "registry.terraform.io/dell/powerflex"
+     }
+   }
+ }

--- a/modules/sdc_host_linux/variables.tf
+++ b/modules/sdc_host_linux/variables.tf
@@ -1,0 +1,70 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+
+# This Terraform module installs the SDC package on a remote Linux host using the `powerflex_sdc_host` resource.
+
+# Define the input variables for the module
+variable "ip" {
+  type        = string
+  description = "Stores the IP address of the remote Linux host."
+}
+
+variable "remote_host" {
+  description = "Stores the SSH credentials for connecting to the remote Linux host."
+  type        = object({
+    # Define the `user` attribute of the `remote` variable.
+    user = string
+    # Define the ssh `private_key` file with path for the SDC login user
+    private_key = optional(string, "")
+    # Define the ssh `certificate` file path, issued to the SDC login user
+    certificate = optional(string, "")
+    password = optional(string)
+  })
+}
+
+variable "mdm_ips" {
+  description = "all the mdms (either primary,secondary or virtual ips) in a comma separated list by cluster if unset will use the mdms of the cluster set in the provider block eg. ['10.10.10.5,10.10.10.6', '10.10.10.7,10.10.10.8']"
+  type        = list(string)
+}
+
+
+variable "scini_url" {
+  type        = string
+  description = "The URL where the SCINI module package is located."
+}
+
+variable "sdc_pkg" {
+  description = "configuration for SDC package like url to download package from, copy as local package or directory on remote server. One of local_dir or remote_dir will be used based on the variable use_remote_path"
+  type = object({
+    # examples "http://example.com/EMC-ScaleIO-sdc-3.6-700.103.Ubuntu.22.04.x86_64.tar", "ftp://username:password@ftpserver/path/to/file"
+    url = string
+    pkg_name = string
+    remote_pkg_name = optional(string)
+    local_dir = string
+    remote_dir = optional(string, "/tmp")
+    # use the SDC package on remote machine path (where SDC is deployed)
+    use_remote_path = bool
+  })
+}
+
+variable "versions" {
+  type = object({
+    pflex = string
+    kernel = string
+  })
+}


### PR DESCRIPTION
Add SDC deployment module for Linux. 

Tests:
Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Destroy complete! Resources: 4 destroyed.