### PR TITLE
Powerflex Manager EXSi/vSphere installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignore Terraform state files
 *.tfstate
 *.tfstate.backup
+*.terraform.lock.hcl
 
 # Ignore Terraform variable files
 terraform.tfvars

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 docs:
-	# install via
-	# go install github.com/terraform-docs/terraform-docs@v0.17.0
+    # install via
+    # go install github.com/terraform-docs/terraform-docs@v0.19.0
 	terraform-docs markdown table --output-file README.md --output-mode inject modules/sdc_host_linux/
 	terraform-docs markdown table --output-file README.md --output-mode inject examples/sdc_host_linux/
 	terraform-docs markdown table --output-file README.md --output-mode inject examples/sdc_host_esxi/
@@ -11,3 +11,5 @@ docs:
 	terraform-docs markdown table --output-file README.md --output-mode inject examples/user/
 	terraform-docs markdown table --output-file README.md --output-mode inject examples/vsphere-ova-vm-deployment/
 	terraform-docs markdown table --output-file README.md --output-mode inject modules/vsphere-ova-vm-deployment/
+	terraform-docs markdown table --output-file README.md --output-mode inject examples/vsphere_pfmp_installation/
+	terraform-docs markdown table --output-file README.md --output-mode inject modules/vsphere_pfmp_installation/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The Terraform Modules for Dell PowerFlex is released and licensed under the MPL-
 
 ## List of Submodules in Terraform Modules for Dell PowerFlex
   * [User](modules/user/README.md)
-  * [SDC Linux](modules/sdc_host_linux/README.md)
-  * [SDC ESXi](modules/sdc_host_esxi/README.md)
-  * [SDC Windows](modules/sdc_host_win/README.md)
+  * [SDC Linux](https://registry.terraform.io/modules/dell/modules/powerflex/latest/submodules/sdc_host_linux)
+  * [SDC ESXi](https://registry.terraform.io/modules/dell/modules/powerflex/latest/submodules/sdc_host_esxi)
+  * [SDC Windows](https://registry.terraform.io/modules/dell/modules/powerflex/latest/submodules/sdc_host_win)
+  * [vSphere OVA Deployment](https://registry.terraform.io/modules/dell/modules/powerflex/latest/submodules/vsphere-ova-vm-deployment)
+  * [Powerflex Management Installer EXSi](https://registry.terraform.io/modules/dell/modules/powerflex/latest/submodules/vsphere_pfmp_installation)

--- a/examples/vsphere-ova-vm-deployment/main.tf
+++ b/examples/vsphere-ova-vm-deployment/main.tf
@@ -36,4 +36,7 @@ module "vsphere_ova_vm_deployment" {
   # vm_name = "example-name"
   # use_remote_path = false
   # allow_unverified_ssl = false
+  # num_cpus = 8
+  # memory = 8120
+  # adapter_type = "vmxnet3"
 }

--- a/examples/vsphere_pfmp_installation/PFMP_Config.json
+++ b/examples/vsphere_pfmp_installation/PFMP_Config.json
@@ -1,0 +1,25 @@
+{
+    "Nodes": [
+      {
+        "hostname": "pfmp-mvm-01",
+        "ipaddress": "10.10.10.11"
+      },
+      {
+        "hostname": "pfmp-mvm-02",
+        "ipaddress": "10.10.10.12"
+      },
+      {
+        "hostname": "pfmp-mvm-03",
+        "ipaddress": "10.10.10.13"
+      }
+    ],
+    "ClusterReservedIPPoolCIDR": "10.42.0.0/23",
+    "ServiceReservedIPPoolCIDR": "10.43.0.0/23",
+    "RoutableIPPoolCIDR": [
+      {
+        "mgmt": "1.2.3.4 - 1.2.3.9"
+      }
+    ],
+    "PFMPHostname": "example.dell.com",
+    "PFMPHostIP": "1.2.3.4"
+  }

--- a/examples/vsphere_pfmp_installation/README.md
+++ b/examples/vsphere_pfmp_installation/README.md
@@ -1,0 +1,39 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_null"></a> [null](#requirement\_null) | 3.2.1 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_vsphere_pfmp_installation"></a> [vsphere\_pfmp\_installation](#module\_vsphere\_pfmp\_installation) | ../../modules/vsphere_pfmp_installation | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_destination_path_to_set_pfmp_config"></a> [destination\_path\_to\_set\_pfmp\_config](#input\_destination\_path\_to\_set\_pfmp\_config) | The path to the PFMP\_Config is set on the installer VM, default is '/opt/dell/pfmp/PFMP\_Installer/config/PFMP\_Config.json' | `string` | `"/opt/dell/pfmp/PFMP_Installer/config/PFMP_Config.json"` | no |
+| <a name="input_installer_node_ip"></a> [installer\_node\_ip](#input\_installer\_node\_ip) | The IP address of the PowerFlex installer node. | `string` | n/a | yes |
+| <a name="input_local_path_to_pfmp_config"></a> [local\_path\_to\_pfmp\_config](#input\_local\_path\_to\_pfmp\_config) | The path to the PFMP\_Config on the local machine, default is './PFMP\_Config.json' | `string` | `"./PFMP_Config.json"` | no |
+| <a name="input_node_1_ip"></a> [node\_1\_ip](#input\_node\_1\_ip) | The IP address of the PowerFlex node 1. | `string` | n/a | yes |
+| <a name="input_node_2_ip"></a> [node\_2\_ip](#input\_node\_2\_ip) | The IP address of the PowerFlex node 2. | `string` | n/a | yes |
+| <a name="input_node_3_ip"></a> [node\_3\_ip](#input\_node\_3\_ip) | The IP address of the PowerFlex node 3. | `string` | n/a | yes |
+| <a name="input_ntp_ip"></a> [ntp\_ip](#input\_ntp\_ip) | The IP address of the NTP server. | `string` | n/a | yes |
+| <a name="input_password"></a> [password](#input\_password) | The password of the PowerFlex nodes and installer, default is 'delladmin' | `string` | `"delladmin"` | no |
+| <a name="input_username"></a> [username](#input\_username) | The username of the PowerFlex nodes and installer, default is 'delladmin' | `string` | `"delladmin"` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/examples/vsphere_pfmp_installation/input.tfvars
+++ b/examples/vsphere_pfmp_installation/input.tfvars
@@ -1,0 +1,22 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+ntp_ip="1.1.2.3"
+installer_node_ip="10.11.12.13"
+node_1_ip="10.11.12.14"
+node_2_ip="10.11.12.15"
+node_3_ip="10.11.12.16"

--- a/examples/vsphere_pfmp_installation/main.tf
+++ b/examples/vsphere_pfmp_installation/main.tf
@@ -1,0 +1,49 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+##########################################
+# Install Powerflex Manager EXSi/vSphere
+##########################################
+
+module "vsphere_pfmp_installation" {
+  # Here source points to the vsphere_pfmp_installation submodule in the modules folder. You can change the value to point it according to your usecase. 
+  source = "../../modules/vsphere_pfmp_installation"
+
+  # Required
+  # Ip address of the ntp server
+  ntp_ip = var.ntp_ip
+  # Ip address of installer node
+  installer_node_ip = var.installer_node_ip
+  # Ip address of node 1
+  node_1_ip = var.node_1_ip
+  # Ip address of node 2
+  node_2_ip = var.node_2_ip
+  # Ip address of node 3
+  node_3_ip = var.node_3_ip
+
+  # Optional values which if not set have default values
+  ## Username to all nodes default is 'delladmin'
+  # username = var.username  # default is 'delladmin'
+  ## Password to all nodes default is 'delladmin'
+  # password = var.password  
+  ## Local path where you are running terraform to the PFMP_Config.json
+  # local_path_to_pfmp_config = var.local_path_to_pfmp_config  # default is './PFMP_Config.json'
+  ## This is default on Powerflex 4.6 or greater
+  # destination_path_to_set_pfmp_config = var.destination_path_to_set_pfmp_config  # default is '/opt/dell/pfmp/PFMP_Installer/config/PFMP_Config.json'
+  ## To use this deployment as a co res deployment
+  # use_co_res = true
+}

--- a/examples/vsphere_pfmp_installation/provider.tf
+++ b/examples/vsphere_pfmp_installation/provider.tf
@@ -1,0 +1,24 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+terraform {
+  required_providers {
+    null = {  
+      source = "hashicorp/null"  
+      version = "3.2.1"  
+    }
+  }
+}

--- a/examples/vsphere_pfmp_installation/variables.tf
+++ b/examples/vsphere_pfmp_installation/variables.tf
@@ -1,0 +1,66 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+variable "ntp_ip" {
+  type = string
+  description = "The IP address of the NTP server."
+}
+
+variable "installer_node_ip" {
+ type = string
+ description = "The IP address of the PowerFlex installer node."
+}
+
+variable "node_1_ip" {
+ type = string
+ description = "The IP address of the PowerFlex node 1."
+}
+
+variable "node_2_ip" {
+ type = string
+ description = "The IP address of the PowerFlex node 2."
+}
+
+variable "node_3_ip" {
+ type = string
+ description = "The IP address of the PowerFlex node 3."
+}
+
+variable "username" {
+  type = string
+  description = "The username of the PowerFlex nodes and installer, default is 'delladmin'"
+  default = "delladmin"
+}
+
+variable "password" {
+  type = string
+  description = "The password of the PowerFlex nodes and installer, default is 'delladmin'"
+  default = "delladmin"
+  sensitive = true
+}
+
+variable "local_path_to_pfmp_config" {
+  type = string
+  description = "The path to the PFMP_Config on the local machine, default is './PFMP_Config.json'"
+  default = "./PFMP_Config.json"
+}
+
+variable "destination_path_to_set_pfmp_config" {
+  type = string
+  description = "The path to the PFMP_Config is set on the installer VM, default is '/opt/dell/pfmp/PFMP_Installer/config/PFMP_Config.json'"
+  default = "/opt/dell/pfmp/PFMP_Installer/config/PFMP_Config.json"
+}

--- a/guides/vsphere_pfmp_installation/README.md
+++ b/guides/vsphere_pfmp_installation/README.md
@@ -1,0 +1,17 @@
+# vSphere OVA Powerflex Manager Installation Guide
+
+### Overview
+*This configuration will be broken into 3 steps, each step will have either a configuration or README with manual steps the user needs to do.* 
+
+## Step 1 Deploy EXSi OVAs
+- Use the vsphere-ova-vm-deployment module to deploy all 4 VMs, the 3 nodes and the installer VM. These VMs can be found on the dell support site here: https://www.dell.com/support/home/en-us/product-support/product/scaleio/drivers
+
+## Step 2 Setup VM interfaces
+- Import the Entrust root certificate to the Vmware vCenter certificate store: https://www.dell.com/support/manuals/en-us/scaleio/pfx_p_software-install-upgrade-46x/add-entrust-root-certificate-to-the-vmware-vcenter-certificate-store?guid=guid-e9b530a7-2ac7-4e00-89cb-70a681a70c2a&lang=en-us . **Note: this only needs to be preformed once. If using the same vCenter for multiple clusters this step only needs to be preformed one time.**
+
+- Follow these steps to set the IP addresses on all 4 of the VMs you deployed in step 1: https://www.dell.com/support/manuals/en-us/scaleio/pfx_p_software-install-upgrade-46x/configure-the-powerflex-management-platform-installer-networking-interface?guid=guid-2e62d072-8286-4313-96cd-6a6203029991&lang=en-us
+
+- Set the property values for the **PFMP_Config.json**. This will be the IPAddress/Hostnames of your 3 nodes as well as information about the IPs needed for your management UI. For more information check out this: https://www.dell.com/support/manuals/en-us/scaleio/pfx_p_software-install-upgrade-46x/deploy-the-powerflex-management-platform-cluster?guid=guid-8ad88b8b-2ab7-4c46-a077-512749a059d2&lang=en-us. **Note: you do not need to do the steps in the above KB articial just set the *PFMP_Config.json* with the values as described. An example of this JSON file is in the examples/vsphere_pfmp_installation/PFMP_Config.json**
+
+## Step 3 Install the Powerflex Manager
+- Use the vsphere_pfmp_installation module to install the Powerflex Manager

--- a/guides/vsphere_pfmp_installation/step1/input.tfvars
+++ b/guides/vsphere_pfmp_installation/step1/input.tfvars
@@ -1,0 +1,28 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+vsphere_user = "example@vsphere.local"
+vsphere_password = "Password"
+vsphere_server = "10.2.6.0"
+
+pfmp_installer_ova_local_path = "/path/to/where/unzip/pmfp-installer.ova"
+pfmp_node_ova_local_path = "/path/to/where/unzip/pmfp-node.ova"
+vsphere_datacenter_name = "My Datacenter"
+vsphere_datastore_name = "My Datastore"
+vsphere_network_name = "My Network"
+vsphere_host_name = "My Host"
+vsphere_resource_pool_name = "My Resource Pool"

--- a/guides/vsphere_pfmp_installation/step1/main.tf
+++ b/guides/vsphere_pfmp_installation/step1/main.tf
@@ -1,0 +1,133 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+terraform {
+  required_providers {
+    vsphere = {
+      source = "hashicorp/vsphere"
+      version = "2.8.2"
+    }
+  }
+}
+
+provider "vsphere" {
+  user                 = var.vsphere_user
+  password             = var.vsphere_password
+  vsphere_server       = var.vsphere_server
+  allow_unverified_ssl = var.allow_unverified_ssl
+  api_timeout          = 10
+}
+
+################################################################################
+# Deploy vSphere OVA Virtual Machines for Powerflex Manager Installer and Nodes
+################################################################################
+
+# Steps to use:
+# 1. Run `terraform init`
+# 2. Fill in the `input.tfvars` with your information and do a `terraform apply --var-file=input.tfvars`
+# For more information about this step check guides/vsphere_pfmp_installation/README.md 
+
+# Deploy the installer node 
+module "vsphere_ova_vm_deployment_installer" {
+  # Here source points to the vsphere-ova-vm-deployment submodule in the modules folder. You can change the value to point it according to your usecase. 
+  source = "../../../modules/vsphere-ova-vm-deployment"
+
+  # Required
+  vm_ova_path = var.pfmp_installer_ova_local_path
+  vsphere_datacenter_name = var.vsphere_datacenter_name
+  vsphere_datastore_name = var.vsphere_datastore_name
+  vsphere_network_name = var.vsphere_network_name
+  vsphere_host_name = var.vsphere_host_name
+  vsphere_resource_pool_name = var.vsphere_resource_pool_name
+
+  # Optional values which if not set have default values
+  vm_name = "pfmp-installer-node"
+  # You can set this to false or comment out if you are using a link to an ova instead of on your local file
+  use_remote_path = true
+  # Recommended number of CPUs according to Powerflex
+  num_cpus = 14
+  # Recommended memory according to Powerflex
+  memory = 32480
+}
+
+# Deploy node 1
+module "vsphere_ova_vm_deployment_node_1" {
+  # Here source points to the vsphere-ova-vm-deployment submodule in the modules folder. You can change the value to point it according to your usecase. 
+  source = "../../../modules/vsphere-ova-vm-deployment"
+
+  # Required
+  vm_ova_path = var.pfmp_node_ova_local_path
+  vsphere_datacenter_name = var.vsphere_datacenter_name
+  vsphere_datastore_name = var.vsphere_datastore_name
+  vsphere_network_name = var.vsphere_network_name
+  vsphere_host_name = var.vsphere_host_name
+  vsphere_resource_pool_name = var.vsphere_resource_pool_name
+
+  vm_name = "pfmp-node-1"
+  # You can set this to false or comment out if you are using a link to an ova instead of on your local file
+  use_remote_path = true
+  # Recommended number of CPUs according to Powerflex
+  num_cpus = 14
+  # Recommended memory according to Powerflex
+  memory = 32480
+}
+
+# Deploy node 2
+module "vsphere_ova_vm_deployment_node_2" {
+  # Here source points to the vsphere-ova-vm-deployment submodule in the modules folder. You can change the value to point it according to your usecase. 
+  source = "../../../modules/vsphere-ova-vm-deployment"
+
+  # Required
+  vm_ova_path = var.pfmp_node_ova_local_path
+  vsphere_datacenter_name = var.vsphere_datacenter_name
+  vsphere_datastore_name = var.vsphere_datastore_name
+  vsphere_network_name = var.vsphere_network_name
+  vsphere_host_name = var.vsphere_host_name
+  vsphere_resource_pool_name = var.vsphere_resource_pool_name
+
+  vm_name = "pfmp-node-2"
+  # You can set this to false or comment out if you are using a link to an ova instead of on your local file
+  use_remote_path = true
+  # Recommended number of CPUs according to Powerflex
+  num_cpus = 14
+  # Recommended memory according to Powerflex
+  memory = 32480
+}
+
+# Deploy node 3
+module "vsphere_ova_vm_deployment_node_3" {
+  # Here source points to the vsphere-ova-vm-deployment submodule in the modules folder. You can change the value to point it according to your usecase. 
+  source = "../../../modules/vsphere-ova-vm-deployment"
+
+  # Required
+  vm_ova_path = var.pfmp_node_ova_local_path
+  vsphere_datacenter_name = var.vsphere_datacenter_name
+  vsphere_datastore_name = var.vsphere_datastore_name
+  vsphere_network_name = var.vsphere_network_name
+  vsphere_host_name = var.vsphere_host_name
+  vsphere_resource_pool_name = var.vsphere_resource_pool_name
+
+
+  # Optional values which if not set have default values
+  vm_name = "pfmp-node-3"
+  # You can set this to false or comment out if you are using a link to an ova instead of on your local file
+  use_remote_path = true
+  # Recommended number of CPUs according to Powerflex
+  num_cpus = 14
+  # Recommended memory according to Powerflex
+  memory = 32480
+}

--- a/guides/vsphere_pfmp_installation/step1/variables.tf
+++ b/guides/vsphere_pfmp_installation/step1/variables.tf
@@ -1,0 +1,71 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+variable "vsphere_user" {
+  type        = string
+  description = "Stores the username of vsphere_user."
+}
+
+variable "vsphere_password" {
+  type        = string
+  description = "Stores the password of vsphere_password."
+}
+
+variable "vsphere_server" {
+  type        = string
+  description = "Stores the host ip/fqdn of the vsphere_server."
+}
+
+variable "vsphere_server" {
+  type        = string
+  description = "Stores the host ip/fqdn of the vsphere_server."
+}
+
+variable "pfmp_installer_ova_local_path" {
+  type        = string
+  description = "local path to the pfmp installer ova"
+}
+
+variable "pfmp_node_ova_local_path" {
+  type        = string
+  description = "local path to the pfmp node ova"
+}
+
+variable "vsphere_datacenter_name" {
+  type        = string
+  description = "Name of datacenter you are deploying the OVAs in"
+}
+
+variable "vsphere_datastore_name" {
+  type        = string
+  description = "Name of datastore you are deploying the OVAs with"
+}
+
+variable "vsphere_network_name" {
+  type        = string
+  description = "Name of network you are deploying the OVAs with"
+}
+
+variable "vsphere_host_name" {
+  type        = string
+  description = "Name of host you are deploying the OVAs with"
+}
+
+variable "vsphere_resource_pool_name" {
+  type        = string
+  description = "Name of resource pool you are deploying the OVAs with"
+}

--- a/guides/vsphere_pfmp_installation/step2/README.md
+++ b/guides/vsphere_pfmp_installation/step2/README.md
@@ -1,0 +1,10 @@
+# Step 2 Manual Steps
+
+### Overview
+*Do the following manual steps after the deployment of the OVAs in step 1*
+
+1. Import the Entrust root certificate to the Vmware vCenter certificate store: https://www.dell.com/support/manuals/en-us/scaleio/pfx_p_software-install-upgrade-46x/add-entrust-root-certificate-to-the-vmware-vcenter-certificate-store?guid=guid-e9b530a7-2ac7-4e00-89cb-70a681a70c2a&lang=en-us . **Note: this only needs to be preformed once. If using the same vCenter for multiple clusters this step only needs to be preformed one time.**
+
+2. Follow these steps to set the IP addresses on all 4 of the VMs you deployed in step 1: https://www.dell.com/support/manuals/en-us/scaleio/pfx_p_software-install-upgrade-46x/configure-the-powerflex-management-platform-installer-networking-interface?guid=guid-2e62d072-8286-4313-96cd-6a6203029991&lang=en-us
+
+3. Set the property values for the **step3/PFMP_Configuration.json**. This will be the IPAddress/Hostnames of your 3 nodes as well as information about the IPs needed for your management UI. For more information check out this: https://www.dell.com/support/manuals/en-us/scaleio/pfx_p_software-install-upgrade-46x/deploy-the-powerflex-management-platform-cluster?guid=guid-8ad88b8b-2ab7-4c46-a077-512749a059d2&lang=en-us. **Note: you do not need to do the steps in the above KB articial just set the *PFMP_Config.json* with the values as described.**

--- a/guides/vsphere_pfmp_installation/step3/PFMP_Config.json
+++ b/guides/vsphere_pfmp_installation/step3/PFMP_Config.json
@@ -1,0 +1,25 @@
+{
+    "Nodes": [
+      {
+        "hostname": "pfmp-mvm-01",
+        "ipaddress": "10.10.10.11"
+      },
+      {
+        "hostname": "pfmp-mvm-02",
+        "ipaddress": "10.10.10.12"
+      },
+      {
+        "hostname": "pfmp-mvm-03",
+        "ipaddress": "10.10.10.13"
+      }
+    ],
+    "ClusterReservedIPPoolCIDR": "10.42.0.0/23",
+    "ServiceReservedIPPoolCIDR": "10.43.0.0/23",
+    "RoutableIPPoolCIDR": [
+      {
+        "mgmt": "1.2.3.4 - 1.2.3.9"
+      }
+    ],
+    "PFMPHostname": "example.dell.com",
+    "PFMPHostIP": "1.2.3.4"
+  }

--- a/guides/vsphere_pfmp_installation/step3/input.tfvars
+++ b/guides/vsphere_pfmp_installation/step3/input.tfvars
@@ -1,0 +1,23 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+ntp_ip="1.1.2.3"
+installer_node_ip="10.11.12.13"
+node_1_ip="10.11.12.14"
+node_2_ip="10.11.12.15"
+node_3_ip="10.11.12.16"
+use_co_res=false

--- a/guides/vsphere_pfmp_installation/step3/main.tf
+++ b/guides/vsphere_pfmp_installation/step3/main.tf
@@ -1,0 +1,53 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+terraform {
+  required_providers {
+    null = {  
+      source = "hashicorp/null"  
+      version = "3.2.1"  
+    }
+  }
+}
+
+##########################################
+# Install Powerflex Manager EXSi/vSphere
+##########################################
+
+# Steps to use:
+# 1. Run `terraform init`
+# 2. Fill in the `input.tfvars` with your information and do a `terraform apply --var-file=input.tfvars`
+# For more information about this step check guides/vsphere_pfmp_installation/README.md 
+
+module "vsphere_pfmp_installation" {
+  # Here source points to the vsphere_pfmp_installation submodule in the modules folder. You can change the value to point it according to your usecase. 
+  source = "../../../modules/vsphere_pfmp_installation"
+
+  # Required
+  # Ip address of the ntp server
+  ntp_ip = var.ntp_ip
+  # Ip address of installer node
+  installer_node_ip = var.installer_node_ip
+  # Ip address of node 1
+  node_1_ip = var.node_1_ip
+  # Ip address of node 2
+  node_2_ip = var.node_2_ip
+  # Ip address of node 3
+  node_3_ip = var.node_3_ip
+  # Do a co-res deployment of manager
+  use_co_res = var.use_co_res
+}

--- a/guides/vsphere_pfmp_installation/step3/variables.tf
+++ b/guides/vsphere_pfmp_installation/step3/variables.tf
@@ -1,0 +1,53 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+variable "ntp_ip" {
+  type = string
+  description = "The IP address of the NTP server."
+}
+
+variable "installer_node_ip" {
+ type = string
+ description = "The IP address of the PowerFlex installer node."
+}
+
+variable "node_1_ip" {
+ type = string
+ description = "The IP address of the PowerFlex node 1."
+}
+
+variable "node_2_ip" {
+ type = string
+ description = "The IP address of the PowerFlex node 2."
+}
+
+variable "node_3_ip" {
+ type = string
+ description = "The IP address of the PowerFlex node 3."
+}
+
+variable "username" {
+  type = string
+  description = "The username of the PowerFlex nodes and installer, default is 'delladmin'"
+  default = "delladmin"
+}
+
+variable "use_co_res" {
+  type = bool
+  description = "Do a co-res deployment of PFMP, default false"
+  default = false
+}

--- a/modules/sdc_host_win/README.md
+++ b/modules/sdc_host_win/README.md
@@ -20,6 +20,31 @@ limitations under the License.
 This Terraform module installs the SDC package on a remote Windows host using the `powerflex_sdc_host` resource.
 It downloads the package either on local machine or remote (Windows) machine and deploys on Windows.
 
+## Usage
+
+```hcl
+module "sdc_host_win" {
+  # Here source points to the sdc_host_win submodule in the modules folder. You can change the value to point it according to your usecase. 
+  source = "../../modules/sdc_host_win"
+  ip = var.ip
+  remote_host = var.remote_host
+  sdc_pkg = var.sdc_pkg
+}
+```
+
+Please refer the SDC Host example [here](../../examples/sdc_host_win/main.tf)
+After providing proper values to all the attributes eg. using terraform.tfvars, then in that workspace, run
+
+```
+terraform init
+terraform apply
+```
+After successful operation of above commands, to remove deployment, you need to execute:
+
+```bash
+terraform destroy 
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -61,31 +86,4 @@ No modules.
 ## Outputs
 
 No outputs.
-
-## Usage
-
-```hcl
-
-module "sdc_host_win" {
-  # Here source points to the sdc_host_win submodule in the modules folder. You can change the value to point it according to your usecase. 
-  source = "../../modules/sdc_host_win"
-
-  ip = var.ip
-  remote_host = var.remote_host
-  sdc_pkg = var.sdc_pkg
-}
-```
-
-Please refer the SDC Host example [here](../../examples/sdc_host_win/main.tf)
-After providing proper values to all the attributes eg. using terraform.tfvars, then in that workspace, run
-
-```
-terraform init
-terraform apply
-```
-After successful operation of above commands, to remove deployment, you need to execute:
-
-```bash
-terraform destroy 
-```
 <!-- END_TF_DOCS -->

--- a/modules/vsphere-ova-vm-deployment/README.md
+++ b/modules/vsphere-ova-vm-deployment/README.md
@@ -47,10 +47,13 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_adapter_type"></a> [adapter\_type](#input\_adapter\_type) | Network Adapter Type for the virtual machine. Defaults to `vmxnet3` Options can be found here: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-AF9E24A8-2CFA-447B-AC83-35D563119667.html | `string` | `"vmxnet3"` | no |
 | <a name="input_allow_unverified_ssl"></a> [allow\_unverified\_ssl](#input\_allow\_unverified\_ssl) | Allow unverified ssl connection | `string` | `true` | no |
 | <a name="input_disk_provisioning"></a> [disk\_provisioning](#input\_disk\_provisioning) | The disk provisioning type for the virtual machine. Options (thin, flat, think, sameAsSource) defaults to `thin` | `string` | `"thin"` | no |
 | <a name="input_ip_allocation_policy"></a> [ip\_allocation\_policy](#input\_ip\_allocation\_policy) | The IP allocation policy for the virtual machine. Defaults to `STATIC_MANUAL` | `string` | `"STATIC_MANUAL"` | no |
 | <a name="input_ip_protocol"></a> [ip\_protocol](#input\_ip\_protocol) | The IP protocol for the virtual machine. Defaults to `IPV4` | `string` | `"IPV4"` | no |
+| <a name="input_memory"></a> [memory](#input\_memory) | Memory for the virtual machine. Defaults to `4060` | `number` | `4060` | no |
+| <a name="input_num_cpus"></a> [num\_cpus](#input\_num\_cpus) | Number of CPUs for the virtual machine. Defaults to `1` | `number` | `1` | no |
 | <a name="input_use_remote_path"></a> [use\_remote\_path](#input\_use\_remote\_path) | Whether or not to use a remote location or a local path, default to `true` | `bool` | `true` | no |
 | <a name="input_vm_name"></a> [vm\_name](#input\_vm\_name) | Name of the PFMP installer VM, default to `new_terraform_vm` | `string` | `"new_terraform_vm"` | no |
 | <a name="input_vm_ova_path"></a> [vm\_ova\_path](#input\_vm\_ova\_path) | Path of the powerflex manager VM OVA, if local `/example/test/example_vm.ova` if remote `https://<ip>/example/example_vm.ova` | `string` | n/a | yes |

--- a/modules/vsphere-ova-vm-deployment/main.tf
+++ b/modules/vsphere-ova-vm-deployment/main.tf
@@ -48,8 +48,15 @@ resource "vsphere_virtual_machine" "vm-installer-remote" {
   host_system_id       = data.vsphere_host.host.id
   resource_pool_id = data.vsphere_resource_pool.pool.id
 
+  num_cpus = var.num_cpus
+  memory = var.memory
   wait_for_guest_net_timeout = 0
   wait_for_guest_ip_timeout  = 0
+
+  network_interface {
+    network_id = data.vsphere_network.network.id
+    adapter_type = var.adapter_type 
+  }
 
   ovf_deploy {
     allow_unverified_ssl_cert = var.allow_unverified_ssl
@@ -59,7 +66,7 @@ resource "vsphere_virtual_machine" "vm-installer-remote" {
     ip_allocation_policy = var.ip_allocation_policy
 
     ovf_network_map = {
-      "VM Network" = data.vsphere_network.network.id
+      network_id = data.vsphere_network.network.id
     }
   }
 }
@@ -73,8 +80,15 @@ resource "vsphere_virtual_machine" "vm-installer-local" {
   host_system_id       = data.vsphere_host.host.id
   resource_pool_id = data.vsphere_resource_pool.pool.id
 
+  num_cpus = var.num_cpus
+  memory = var.memory
   wait_for_guest_net_timeout = 0
   wait_for_guest_ip_timeout  = 0
+
+  network_interface {
+    network_id = data.vsphere_network.network.id
+    adapter_type = var.adapter_type 
+  }
 
   ovf_deploy {
     allow_unverified_ssl_cert = var.allow_unverified_ssl

--- a/modules/vsphere-ova-vm-deployment/variables.tf
+++ b/modules/vsphere-ova-vm-deployment/variables.tf
@@ -80,3 +80,21 @@ variable "allow_unverified_ssl" {
   description = "Allow unverified ssl connection"
   default = true
 }
+
+variable "num_cpus" {
+  type = number
+  description = "Number of CPUs for the virtual machine. Defaults to `1`"
+  default = 1
+}
+
+variable "memory" {
+  type = number
+  description = "Memory for the virtual machine. Defaults to `4060`"
+  default = 4060
+}
+
+variable "adapter_type" {
+  type = string
+  description = "Network Adapter Type for the virtual machine. Defaults to `vmxnet3` Options can be found here: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-AF9E24A8-2CFA-447B-AC83-35D563119667.html"
+  default = "vmxnet3"
+}

--- a/modules/vsphere_pfmp_installation/README.md
+++ b/modules/vsphere_pfmp_installation/README.md
@@ -1,0 +1,47 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_null"></a> [null](#requirement\_null) | 3.2.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.1 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [null_resource.copy_pfmp_config](https://registry.terraform.io/providers/hashicorp/null/3.2.1/docs/resources/resource) | resource |
+| [terraform_data.install_pfmp](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [terraform_data.set_ntp](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [terraform_data.set_ntp_node1](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [terraform_data.set_ntp_node2](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [terraform_data.set_ntp_node3](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_destination_path_to_set_pfmp_config"></a> [destination\_path\_to\_set\_pfmp\_config](#input\_destination\_path\_to\_set\_pfmp\_config) | The path to the PFMP\_Config is set on the installer VM, default is '/opt/dell/pfmp/PFMP\_Installer/config/PFMP\_Config.json' | `string` | `"/opt/dell/pfmp/PFMP_Installer/config/PFMP_Config.json"` | no |
+| <a name="input_installer_node_ip"></a> [installer\_node\_ip](#input\_installer\_node\_ip) | The IP address of the PowerFlex installer node. | `string` | n/a | yes |
+| <a name="input_local_path_to_pfmp_config"></a> [local\_path\_to\_pfmp\_config](#input\_local\_path\_to\_pfmp\_config) | The path to the PFMP\_Config on the local machine, default is './PFMP\_Config.json' | `string` | `"./PFMP_Config.json"` | no |
+| <a name="input_node_1_ip"></a> [node\_1\_ip](#input\_node\_1\_ip) | The IP address of the PowerFlex node 1. | `string` | n/a | yes |
+| <a name="input_node_2_ip"></a> [node\_2\_ip](#input\_node\_2\_ip) | The IP address of the PowerFlex node 2. | `string` | n/a | yes |
+| <a name="input_node_3_ip"></a> [node\_3\_ip](#input\_node\_3\_ip) | The IP address of the PowerFlex node 3. | `string` | n/a | yes |
+| <a name="input_ntp_ip"></a> [ntp\_ip](#input\_ntp\_ip) | The IP address of the NTP server. | `string` | n/a | yes |
+| <a name="input_password"></a> [password](#input\_password) | The password of the PowerFlex nodes and installer, default is 'delladmin' | `string` | `"delladmin"` | no |
+| <a name="input_username"></a> [username](#input\_username) | The username of the PowerFlex nodes and installer, default is 'delladmin' | `string` | `"delladmin"` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/vsphere_pfmp_installation/main.tf
+++ b/modules/vsphere_pfmp_installation/main.tf
@@ -1,0 +1,163 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+# Set the ntp for installer node
+resource terraform_data set_ntp {
+   connection {
+    type = "ssh"
+    host = var.installer_node_ip
+    user = var.username
+    password = var.password
+  }
+  input = {
+    ntp_ip = var.ntp_ip
+  }
+  provisioner "remote-exec" {
+    inline = [
+        "sudo sh -c 'echo server ${self.input.ntp_ip} iburst >> /etc/chrony.conf'",
+        "sudo systemctl start chronyd",
+        "sudo systemctl enable chronyd",
+        "sudo systemctl restart chronyd"
+    ]
+  }
+}
+
+# Set the ntp for node 1
+resource terraform_data set_ntp_node1 {
+   connection {
+    type = "ssh"
+    host = var.node_1_ip
+    user = var.username
+    password = var.password
+  }
+  input = {
+    ntp_ip = var.ntp_ip
+  }
+  provisioner "remote-exec" {
+    inline = [
+        "sudo sh -c 'echo server ${self.input.ntp_ip} iburst >> /etc/chrony.conf'",
+        "sudo systemctl start chronyd",
+        "sudo systemctl enable chronyd",
+        "sudo systemctl restart chronyd"
+    ]
+  }
+}
+
+# Set the ntp for node 2
+resource terraform_data set_ntp_node2 {
+   connection {
+    type = "ssh"
+    host = var.node_2_ip
+    user = var.username
+    password = var.password
+  }
+  input = {
+    ntp_ip = var.ntp_ip
+  }
+  provisioner "remote-exec" {
+    inline = [
+        "sudo sh -c 'echo server ${self.input.ntp_ip} iburst >> /etc/chrony.conf'",
+        "sudo systemctl start chronyd",
+        "sudo systemctl enable chronyd",
+        "sudo systemctl restart chronyd"
+    ]
+  }
+}
+
+# Set the ntp for node 3
+resource terraform_data set_ntp_node3 {
+   connection {
+    type = "ssh"
+    host = var.node_3_ip
+    user = var.username
+    password = var.password
+  }
+  input = {
+    ntp_ip = var.ntp_ip
+  }
+  provisioner "remote-exec" {
+    inline = [
+        "sudo sh -c 'echo server ${self.input.ntp_ip} iburst >> /etc/chrony.conf'",
+        "sudo systemctl start chronyd",
+        "sudo systemctl enable chronyd",
+        "sudo systemctl restart chronyd"
+    ]
+  }
+}
+
+# Copy the PFMP config to the installer vm
+resource "null_resource" "copy_pfmp_config" {
+
+  connection {
+    type = "ssh"
+    host = var.installer_node_ip
+    user = var.username
+    password = var.password
+    agent = false
+  }
+
+  # Copy file over to installer VM
+  provisioner "file" {
+    source = var.local_path_to_pfmp_config
+    destination = "PFMP_Config.json"
+  }
+
+  # Move the file to the correct location (2 steps because the second one needs sudo)
+  provisioner "remote-exec" {
+    inline = [
+        "sudo cp PFMP_Config.json /opt/dell/pfmp/PFMP_Installer/config/PFMP_Config.json",
+    ]
+  }
+}
+
+locals {
+  // If use_co_res is true the first statement is taken with the `-r` flag else it will be non-co-res
+  pfmp_install_cmd = var.use_co_res ? "sudo ./install_PFMP.sh -r ${var.username}:${var.password}" : "sudo ./install_PFMP.sh ${var.username}:${var.password}"
+}
+
+# Installer node, and run install script
+resource terraform_data install_pfmp {
+  input = {
+    username = var.username
+    password = var.password
+    installer_node_ip = var.installer_node_ip
+    pfmp_install_cmd_output = local.pfmp_install_cmd
+  }
+
+  connection {
+    type = "ssh"
+    host = self.output.installer_node_ip
+    user = self.output.username
+    password = self.output.password
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+        "cd /opt/dell/pfmp/PFMP_Installer/scripts",
+        "sudo ./setup_installer.sh",
+        "${local.pfmp_install_cmd}",
+    ]
+  }
+  // Run this step last
+  depends_on = [ 
+    null_resource.copy_pfmp_config,
+    terraform_data.set_ntp,
+    terraform_data.set_ntp_node1,
+    terraform_data.set_ntp_node2,
+    terraform_data.set_ntp_node3
+  ]
+}

--- a/modules/vsphere_pfmp_installation/provider.tf
+++ b/modules/vsphere_pfmp_installation/provider.tf
@@ -1,0 +1,24 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+terraform {
+  required_providers {
+    null = {  
+      source = "hashicorp/null"  
+      version = "3.2.1"  
+    }
+  }
+}

--- a/modules/vsphere_pfmp_installation/variables.tf
+++ b/modules/vsphere_pfmp_installation/variables.tf
@@ -1,0 +1,71 @@
+# /*
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+# Licensed under the Mozilla Public License Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://mozilla.org/MPL/2.0/
+
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+variable "ntp_ip" {
+  type = string
+  description = "The IP address of the NTP server."
+}
+
+variable "installer_node_ip" {
+ type = string
+ description = "The IP address of the PowerFlex installer node."
+}
+
+variable "node_1_ip" {
+ type = string
+ description = "The IP address of the PowerFlex node 1."
+}
+
+variable "node_2_ip" {
+ type = string
+ description = "The IP address of the PowerFlex node 2."
+}
+
+variable "node_3_ip" {
+ type = string
+ description = "The IP address of the PowerFlex node 3."
+}
+
+variable "username" {
+  type = string
+  description = "The username of the PowerFlex nodes and installer, default is 'delladmin'"
+  default = "delladmin"
+}
+
+variable "password" {
+  type = string
+  description = "The password of the PowerFlex nodes and installer, default is 'delladmin'"
+  default = "delladmin"
+}
+
+variable "local_path_to_pfmp_config" {
+  type = string
+  description = "The path to the PFMP_Config on the local machine, default is './PFMP_Config.json'"
+  default = "./PFMP_Config.json"
+}
+
+variable "destination_path_to_set_pfmp_config" {
+  type = string
+  description = "The path to the PFMP_Config is set on the installer VM, default is '/opt/dell/pfmp/PFMP_Installer/config/PFMP_Config.json'"
+  default = "/opt/dell/pfmp/PFMP_Installer/config/PFMP_Config.json"
+}
+
+variable "use_co_res" {
+  type = bool
+  description = "Do a co-res deployment of PFMP, default false"
+  default = false
+}


### PR DESCRIPTION
## Install Powerflex Manager EXSi/vSphere

- Add module to do steps for Powerflex Manager Deployment and install using public OVAs
- Add guide on multi step process for deploying and installing the Powerflex manager
- Enhance the vsphere-ova-vm-deployment to set the following fields
   - num_cpus
   - memory
   - network_adapter_type