### PR TITLE
Module Example Updates

### DIFF
--- a/examples/aws_install/README.md
+++ b/examples/aws_install/README.md
@@ -77,6 +77,96 @@ ami = {
 multi_az = false
 ```
 
+main.tf
+```hcl
+
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "5.90.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "" // Input your region i.e "us-east-1"
+  // For more information on the different aws provider configurations check out here: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
+  profile = "" // Input your aws provider i.e "default"
+}
+
+module "aws_infra" {
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/aws_infra"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
+  vpc_name     = var.vpc_name
+  subnet_ids = var.subnet_ids
+  vpn_security_group = var.security_group
+  multi_az = var.multi_az
+  instance_type = var.instance_type
+  instance_count = var.instance_count
+  deployment_type = var.deployment_type
+  key_path = var.key_path
+  private_key_path = var.private_key_path
+  creator                = var.creator
+  application_version    = var.application_version
+  bastion_config = var.bastion_config
+  private_subnet_cidr = var.private_subnet_cidr
+  disk_size = var.disk_size
+  disk_count = var.disk_count
+}
+
+module "load-balancer" {
+  source  = "dell/modules/powerflex//modules/aws_prereq/load_balancer"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
+  application_version    = var.application_version
+  creator                = var.creator
+  management_ids         = module.aws_infra.management_ids
+  subnet_ids             = var.subnet_ids
+  vpc_id                 = var.vpc_name
+  security_group         = var.security_group
+  depends_on             = [module.aws_infra]
+}
+
+module "aws_install" {
+  source = "dell/modules/powerflex//modules/aws_install"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
+  installer_node_ip = module.aws_infra.installer_ip
+  co_res_ips = module.aws_infra.co_res_ips
+  device_mapping = module.aws_infra.device_mapping
+  loadbalancer_dns = module.load-balancer.loadbalancer_dns
+  loadbalancer_ip = module.load-balancer.loadbalancer_private_ip
+  node_ips = module.aws_infra.management_ips
+  management_ips = module.aws_infra.management_ips
+  instance_type = var.instance_type
+  key_path = var.key_path
+  private_key_path = var.private_key_path
+  multi_az = var.multi_az
+  bastion_config = var.bastion_config
+  interpreter = var.interpreter
+  depends_on             = [module.load-balancer]
+}
+
+output "loadbalancer_dns" {
+  description = "The DNS of the loadbalancer."
+  value       = module.load-balancer.loadbalancer_dns
+}
+
+
+output "loadbalancer_private_ip" {
+  description = "The IP of the loadbalancer. Apex block management webui can be accessed from this IP."
+  value       = module.load-balancer.loadbalancer_private_ip
+}
+
+output "installer_ip" {
+  description = "The private ip of the installer server"
+  value       = module.aws_infra.installer_ip
+}
+```
+
 Refer guides and individual module's README.md file for more information and variables.
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/examples/aws_install/main.tf
+++ b/examples/aws_install/main.tf
@@ -19,7 +19,12 @@
 # main.tf
 
 module "aws_infra" {
-  source = "../../modules/aws_infra"
+  # Here the source points to the a local instance of the submodule in the modules folder, if you have and instance of the modules folder locally.
+  # source = "../../modules/aws_infra"
+
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/aws_infra"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
 
   vpc_name     = var.vpc_name
   subnet_ids = var.subnet_ids
@@ -39,7 +44,9 @@ module "aws_infra" {
 }
 
 module "load-balancer" {
-  source                 = "../../modules/aws_prereq/load_balancer"
+  source  = "dell/modules/powerflex//modules/aws_prereq/load_balancer"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
   application_version    = var.application_version
   creator                = var.creator
   management_ids         = module.aws_infra.management_ids
@@ -50,7 +57,8 @@ module "load-balancer" {
 }
 
 module "aws_install" {
-  source = "../../modules/aws_install"
+  source = "dell/modules/powerflex//modules/aws_install"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
 
   installer_node_ip = module.aws_infra.installer_ip
   co_res_ips = module.aws_infra.co_res_ips

--- a/examples/aws_install/provider.tf
+++ b/examples/aws_install/provider.tf
@@ -15,7 +15,11 @@
 # limitations under the License.
 # */
 
-provider "aws" {
-  region = "us-east-1"  # Change to your desired region
-  profile = "default"
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "5.90.0"
+    }
+  }
 }

--- a/examples/azure_core/providers.tf
+++ b/examples/azure_core/providers.tf
@@ -26,10 +26,3 @@ terraform {
   }
 }
 
-provider "powerflex" {
-  username = var.username
-  password = var.password
-  endpoint = var.endpoint
-  insecure = var.insecure
-  timeout  = 120
-}

--- a/examples/azure_pfmp/README.md
+++ b/examples/azure_pfmp/README.md
@@ -20,6 +20,52 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+main.tf
+```hcl
+module "azure_pfmp" {
+  # Here the source points to the a local instance of the submodule in the modules folder, if you have and instance of the modules folder locally.
+  # source         = "../../modules/azure_pfmp"
+
+  source  = "dell/modules/powerflex//modules/azure_pfmp"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
+  bastion_subnet = var.bastion_subnet
+  cluster = {
+    node_count        = var.cluster_node_count
+    is_multi_az       = var.is_multi_az
+    deployment_type   = var.deployment_type
+    data_disk_count   = var.data_disk_count
+    data_disk_size_gb = var.data_disk_size_gb
+  }
+  data_disk_logical_sector_size  = var.data_disk_logical_sector_size
+  enable_bastion                 = var.enable_bastion
+  enable_jumphost                = var.enable_jumphost
+  enable_sql_workload_vm         = var.enable_sql_workload_vm
+  existing_resource_group        = var.existing_resource_group
+  installer_gallary_image        = var.installer_gallary_image
+  location                       = var.location
+  login_credential               = var.login_credential
+  pfmp_lb_ip                     = var.pfmp_lb_ip
+  prefix                         = var.prefix
+  ssh_key                        = var.ssh_key
+  storage_instance_gallary_image = var.storage_instance_gallary_image
+  subnets                        = var.subnets
+  vnet_address_space             = var.vnet_address_space
+}
+
+output "bastion_tunnel" {
+  value = module.azure_pfmp.bastion_tunnel != null ? "az network bastion tunnel --name ${module.azure_pfmp.bastion_tunnel.bastion_name} --resource-group ${module.azure_pfmp.bastion_tunnel.resource_group} --target-resource-id ${module.azure_pfmp.bastion_tunnel.installer_id} --resource-port 22 --port 1111" : null
+}
+
+output "pfmp_ip" {
+  value = module.azure_pfmp.pfmp_ip
+}
+
+output "sds_nodes" {
+  value = module.azure_pfmp.sds_nodes[*].ip
+}
+```
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/examples/azure_pfmp/main.tf
+++ b/examples/azure_pfmp/main.tf
@@ -16,7 +16,12 @@
 # */
 
 module "azure_pfmp" {
-  source         = "../../modules/azure_pfmp"
+  # Here the source points to the a local instance of the submodule in the modules folder, if you have and instance of the modules folder locally.
+  # source         = "../../modules/azure_pfmp"
+
+  source  = "dell/modules/powerflex//modules/azure_pfmp"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
   bastion_subnet = var.bastion_subnet
   cluster = {
     node_count        = var.cluster_node_count

--- a/examples/sdc_host_esxi/README.md
+++ b/examples/sdc_host_esxi/README.md
@@ -42,34 +42,43 @@ After successful operation of above commands, to remove deployment, you need to 
 terraform destroy 
 ```
 
-## Example inputs
-
-terraform.tfvars
+## Example main.tf
+main.tf
 ```hcl
-remote_host={
-    user = "root"
-    private_key = ""
-    certificate = ""
-    password = "password"
-    }
-
-
-ip="1.2.11.10"
-
-sdc_pkg = {
-    url = "https://example.com/sdc-4.5.0.263-esx8.x.zip"
-    local_pkg = "sdc-4.5.0.263-esx8.x.zip"
-    local_dir = "/tmp"
-    pkg_name = "sdc-4.5.0.263-esx8.x.zip"
-    remote_pkg_name = "emc-sdc-package.zip"
-    remote_dir = "/tmp"
-    use_remote_path = true
+terraform {
+   required_providers {
+     powerflex = {
+       version = ">=1.6.0"
+       source  = "registry.terraform.io/dell/powerflex"
+     }
+   }
 }
 
-powerflex_config = {
-    username = "admin"
-    endpoint = "https://1.2.3.4:443"
-    password = "Password" 
+module "sdc_host_esxi" {
+  
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/sdc_host_esxi"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
+  # Host information of the host which the SDC should be installed upone
+  remote_host={
+    user = "root" // SSH User
+    password = "password" // SSH Password
+  }
+  
+  sdc_name = "terraform-sdc"// The name of the SDC will default to 'terraform-sdc'
+  
+  ip="1.2.11.10" // IP of the EsXi Host which the SDC will be installed upon
+  
+  # SDC Package information
+  sdc_pkg = {
+    url = "https://example.com/sdc-4.5.0.263-esx8.x.zip" // SDC Package URL Download Location. For FTP Example like "ftp://username:password@ftpserver/path/to/file"
+    #local_dir = "/tmp" // If you want to download the package locally, put the path to download
+    pkg_name = "sdc-4.5.0.263-esx8.x.zip" // SDC downloaded package name
+    remote_pkg_name = "emc-sdc-package.zip" // Do not update this value
+    remote_dir = "/tmp" // Where the package will be downloaded on the ESXi Host
+    use_remote_path = true // Always set this to true
+  }
 }
 ```
 
@@ -100,7 +109,6 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_ip"></a> [ip](#input\_ip) | Stores the IP address of the remote Linux host. | `string` | n/a | yes |
 | <a name="input_mdm_ips"></a> [mdm\_ips](#input\_mdm\_ips) | all the mdms (either primary,secondary or virtual ips) in a comma separated list by cluster if unset will use the mdms of the cluster set in the provider block eg. ['10.10.10.5,10.10.10.6', '10.10.10.7,10.10.10.8'] | `list(string)` | `[]` | no |
-| <a name="input_powerflex_config"></a> [powerflex\_config](#input\_powerflex\_config) | Stores the configuration for terraform PowerFlex provider. | <pre>object({<br>    # Define the attributes of the configuration for terraform PowerFlex provider.<br>    username = string<br>    endpoint = string<br>    password = string<br>  })</pre> | n/a | yes |
 | <a name="input_remote_host"></a> [remote\_host](#input\_remote\_host) | Stores the SSH credentials for connecting to the remote Linux host. | <pre>object({<br>    # Define the `user` attribute of the `remote` variable.<br>    user = string<br>    # Define the ssh `private_key` file with path for the SDC login user<br>    private_key = optional(string, "")<br>    # Define the ssh `certificate` file path, issued to the SDC login user<br>    certificate = optional(string, "")<br>    password = optional(string)<br>  })</pre> | n/a | yes |
 | <a name="input_sdc_pkg"></a> [sdc\_pkg](#input\_sdc\_pkg) | configuration for SDC package like url to download package from, copy as local package or directory on remote server. One of local\_dir or remote\_dir will be used based on the variable use\_remote\_path | <pre>object({<br>    # examples "http://example.com/EMC-ScaleIO-sdc-3.6-700.103.Ubuntu.22.04.x86_64.tar", "ftp://username:password@ftpserver/path/to/file"<br>    url = string<br>    pkg_name = string<br>    remote_pkg_name = optional(string)<br>    local_dir = string<br>    remote_dir = optional(string, "/tmp")<br>    # use the SDC package on remote machine path (where SDC is deployed)<br>    use_remote_path = bool<br>  })</pre> | n/a | yes |
 

--- a/examples/sdc_host_esxi/main.tf
+++ b/examples/sdc_host_esxi/main.tf
@@ -21,11 +21,16 @@
 
 module "sdc_host_esxi" {
   # Here source points to the sdc_host_esxi submodule in the modules folder. You can change the value to point it according to your usecase. 
-  source = "../../modules/sdc_host_esxi"
+  # source = "../../modules/sdc_host_esxi"
   
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/sdc_host_esxi"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
   ip = var.ip
   remote_host = var.remote_host
   sdc_pkg = var.sdc_pkg
   mdm_ips = var.mdm_ips
+  sdc_name = "terraform-sdc"// The name of the SDC will default to 'terraform-sdc'
 }
 

--- a/examples/sdc_host_esxi/provider.tf
+++ b/examples/sdc_host_esxi/provider.tf
@@ -23,10 +23,3 @@ terraform {
    }
  }
 
-provider "powerflex" {
-  username = var.powerflex_config.username
-  password = var.powerflex_config.password
-  endpoint = var.powerflex_config.endpoint
-  insecure = true
-  timeout  = 120
-}

--- a/examples/sdc_host_esxi/variables.tf
+++ b/examples/sdc_host_esxi/variables.tf
@@ -37,16 +37,6 @@ variable "remote_host" {
   })
 }
 
-variable "powerflex_config" {
-  description = "Stores the configuration for terraform PowerFlex provider."
-  type        = object({
-    # Define the attributes of the configuration for terraform PowerFlex provider.
-    username = string
-    endpoint = string
-    password = string
-  })
-}
-
 variable "mdm_ips" {
   description = "all the mdms (either primary,secondary or virtual ips) in a comma separated list by cluster if unset will use the mdms of the cluster set in the provider block eg. ['10.10.10.5,10.10.10.6', '10.10.10.7,10.10.10.8']"
   type        = list(string)

--- a/examples/sdc_host_linux/main.tf
+++ b/examples/sdc_host_linux/main.tf
@@ -21,8 +21,12 @@
 ##############
 
 module "sdc_host_linux" {
-  # Here source points to the sdc_host_linux submodule in the modules folder. You can change the value to point it according to your usecase. 
-  source = "../../modules/sdc_host_linux"
+  # Here the source points to the a local instance of the submodule in the modules folder, if you have and instance of the modules folder locally.
+  # source = "../../modules/sdc_host_linux"
+
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/sdc_host_linux"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
 
   versions = var.versions
   ip = var.ip
@@ -30,5 +34,6 @@ module "sdc_host_linux" {
   scini = var.scini
   sdc_pkg = var.sdc_pkg
   mdm_ips = var.mdm_ips
+  sdc_name = "terraform-sdc"// The name of the SDC will default to 'terraform-sdc'
 }
 

--- a/examples/sdc_host_linux/provider.tf
+++ b/examples/sdc_host_linux/provider.tf
@@ -23,11 +23,3 @@ terraform {
    }
  }
 
-
-provider "powerflex" {
-  username = var.powerflex_config.username
-  password = var.powerflex_config.password
-  endpoint = var.powerflex_config.endpoint
-  insecure = true
-  timeout  = 120
-}

--- a/examples/sdc_host_linux/variables.tf
+++ b/examples/sdc_host_linux/variables.tf
@@ -37,16 +37,6 @@ variable "remote_host" {
 
 }
 
-variable "powerflex_config" {
-  description = "Stores the configuration for terraform PowerFlex provider."
-  type        = object({
-    # Define the attributes of the configuration for terraform PowerFlex provider.
-    username = string
-    endpoint = string
-    password = string
-  })
-}
-
 variable "mdm_ips" {
   description = "all the mdms (either primary,secondary or virtual ips) in a comma separated list by cluster if unset will use the mdms of the cluster set in the provider block eg. ['10.10.10.5,10.10.10.6', '10.10.10.7,10.10.10.8']"
   type        = list(string)

--- a/examples/sdc_host_win/README.md
+++ b/examples/sdc_host_win/README.md
@@ -26,34 +26,36 @@ limitations under the License.
 This Terraform module installs the SDC package on a remote Windows host using the `powerflex_sdc_host` resource.
 It downloads the package either on local machine or remote (Windows) machine and deploys on Windows.
 
-## Example inputs
+## Example
 
-terraform.tfvars
+main.tf
 ```hcl
-remote_host={
-    user = "root"
-    private_key = ""
-    certificate = ""
-    password = "password"
+terraform {
+  required_providers {
+    powerflex = {
+      version = ">=1.6.0"
+      source  = "registry.terraform.io/dell/powerflex"
+      }
     }
-
-
-ip="1.2.11.10"
-
-sdc_pkg = {
-    url = "http://example.com/EMC-ScaleIO-sdc-3.6-300.107.msi"
-    local_pkg = "sdc-4.5.0.263-esx8.x.zip"
-    local_dir = "/tmp"
-    pkg_name = "sdc-4.5.0.263-esx8.x.zip"
-    remote_pkg_name = "emc-sdc-package.zip"
-    remote_dir = "/tmp"
-    use_remote_path = true
 }
 
-powerflex_config = {
-    username = "admin"
-    endpoint = "https://1.2.3.4:443"
-    password = "Password" 
+module "sdc_host_win" {
+  source = "dell/modules/powerflex//modules/sdc_host_win"
+  version = "x.x.x" //Grab the latest but for example 1.2.0
+  
+  name = "terraform-windows-sdc" // Update to the value you wish to name your SDC
+  ip = "x.x.x.x" // Update to the IP of the VM which you want to install your SDC packages upon 
+  remote_host = {
+    user = "example-user" // Update to the username used to access the windows VM
+    password = "example-password" // Update to the password used ot access the windows VM 
+  }
+  sdc_name = "terraform-sdc"// The name of the SDC will default to 'terraform-sdc'
+  sdc_pkg = {
+    url = "http://example.com/EMC-ScaleIO-sdc-4.6-x.x.msi" // URL to place where the sdc.msi file is hosted FTP Example: "ftp://username:password@ftpserver/path/to/EMC-ScaleIO-sdc-4.6-x.x.msi" # the name of the SDC package saved in local directory.
+    pkg_name = "EMC-ScaleIO-sdc-4.6-x.x.msi" 
+    local_dir = "/tmp" // Where the sdc_pkg will be downloaded
+    use_remote_path = false // download and use the SDC package on remote machine path (where SDC is going to be deployed)
+  }
 }
 ```
 
@@ -84,7 +86,6 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_ip"></a> [ip](#input\_ip) | Stores the IP address of the remote Windows host. | `string` | n/a | yes |
 | <a name="input_mdm_ips"></a> [mdm\_ips](#input\_mdm\_ips) | all the mdms (either primary,secondary or virtual ips) in a comma separated list by cluster if unset will use the mdms of the cluster set in the provider block eg. ['10.10.10.5,10.10.10.6', '10.10.10.7,10.10.10.8'] | `list(string)` | `[]` | no |
-| <a name="input_powerflex_config"></a> [powerflex\_config](#input\_powerflex\_config) | Stores the configuration for terraform PowerFlex provider. | <pre>object({<br>    # Define the attributes of the configuration for terraform PowerFlex provider.<br>    username = string<br>    endpoint = string<br>    password = string<br>  })</pre> | n/a | yes |
 | <a name="input_remote_host"></a> [remote\_host](#input\_remote\_host) | Stores the credentials for connecting to the remote Windows host. | <pre>object({<br>    # Define the `user` attribute of the `remote` variable.<br>    user = string<br>    password = string<br>  })</pre> | n/a | yes |
 | <a name="input_sdc_pkg"></a> [sdc\_pkg](#input\_sdc\_pkg) | configuration for SDC package like url to download package from, copy as local package or at directory on remote server. | <pre>object({<br>    # examples "http://example.com/EMC-ScaleIO-sdc-3.6-700.103.msi", "ftp://username:password@ftpserver/path/to/file"<br>    url = string<br>    # the name of the SDC package saved in local directory.<br>    pkg_name = string<br>    # the local directory where the SDC package will be downloaded.<br>    local_dir = string<br>    # download and use the SDC package on remote machine path (where SDC is going to be deployed)<br>    use_remote_path = bool<br>  })</pre> | n/a | yes |
 

--- a/examples/sdc_host_win/main.tf
+++ b/examples/sdc_host_win/main.tf
@@ -21,12 +21,17 @@
 ##############
 
 module "sdc_host_win" {
-  # Here source points to the sdc_host_win submodule in the modules folder. You can change the value to point it according to your usecase. 
-  source = "../../modules/sdc_host_win"
+  # Here the source points to the a local instance of the submodule in the modules folder, if you have and instance of the modules folder locally.
+  # source = "../../modules/sdc_host_win"
+
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/sdc_host_win"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
 
   ip = var.ip
   remote_host = var.remote_host
   sdc_pkg = var.sdc_pkg
   mdm_ips = var.mdm_ips
+  sdc_name = "terraform-sdc"// The name of the SDC will default to 'terraform-sdc'
 }
 

--- a/examples/sdc_host_win/provider.tf
+++ b/examples/sdc_host_win/provider.tf
@@ -6,12 +6,3 @@ terraform {
      }
    }
  }
-
-
-provider "powerflex" {
-  username = var.powerflex_config.username
-  password = var.powerflex_config.password
-  endpoint = var.powerflex_config.endpoint
-  insecure = true
-  timeout  = 120
-}

--- a/examples/sdc_host_win/variables.tf
+++ b/examples/sdc_host_win/variables.tf
@@ -33,16 +33,6 @@ variable "remote_host" {
 
 }
 
-variable "powerflex_config" {
-  description = "Stores the configuration for terraform PowerFlex provider."
-  type        = object({
-    # Define the attributes of the configuration for terraform PowerFlex provider.
-    username = string
-    endpoint = string
-    password = string
-  })
-}
-
 variable "mdm_ips" {
   description = "all the mdms (either primary,secondary or virtual ips) in a comma separated list by cluster if unset will use the mdms of the cluster set in the provider block eg. ['10.10.10.5,10.10.10.6', '10.10.10.7,10.10.10.8']"
   type        = list(string)

--- a/examples/user/README.md
+++ b/examples/user/README.md
@@ -20,6 +20,43 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+## Example
+
+main.tf
+```hcl
+
+terraform {
+  required_providers {
+    powerflex = {
+      version = "1.2.0"
+      source  = "registry.terraform.io/dell/powerflex"
+    }
+    null = {  
+      source = "hashicorp/null"  
+      version = "3.2.1"  
+    }
+  }
+    
+}
+
+module "user_creation" {
+  # Here the source points to the a local instance of the submodule in the modules folder, if you have and instance of the modules folder locally. 
+  # source = "../../modules/user"
+
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/user"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
+  newUserName = "user"
+  userRole = "Monitor"
+  userPassword = "Password1234"
+  mdmUserName = "root"
+  mdmPassword = "Password"
+  mdmHost = "10.x.x.x"
+  newPassword = "Password123"
+}
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/examples/user/main.tf
+++ b/examples/user/main.tf
@@ -3,12 +3,13 @@
 ##############
 
 module "user_creation" {
-  # Here source points to the user submodule in the modules folder. You can change the value to point it according to your usecase. 
-  source = "../../modules/user"
+  # Here the source points to the a local instance of the submodule in the modules folder, if you have and instance of the modules folder locally. 
+  # source = "../../modules/user"
 
-  username = "admin"
-  password = "Password"
-  endpoint = "10.x.x.x"
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/user"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
   newUserName = "user"
   userRole = "Monitor"
   userPassword = "Password1234"

--- a/examples/user/provider.tf
+++ b/examples/user/provider.tf
@@ -28,12 +28,3 @@ terraform {
   }
     
 }
-provider "powerflex" {
-  username = var.username
-  password = var.password
-  endpoint = var.endpoint
-  insecure = true
-  timeout  = 120
-}
-
-provider "null" {}

--- a/examples/vsphere-ova-vm-deployment/README.md
+++ b/examples/vsphere-ova-vm-deployment/README.md
@@ -20,10 +20,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-## Example inputs
 
-terraform.tfvars
+## Example
+
+main.tf
 ```hcl
+module "vsphere_ova_vm_deployment" {
+  # Here the source points to the a local instance of the submodule in the modules folder, if you have and instance of the modules folder locally.
+  # source = "../../modules/vsphere-ova-vm-deployment"
+
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/vsphere_pfmp_installation"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
   # Required
   vm_ova_path = "https://example.com/path/to/example.ova"
   vsphere_datacenter_name = "datacenter"
@@ -37,6 +46,10 @@ terraform.tfvars
   # vm_name = "example-name"
   # use_remote_path = false
   # allow_unverified_ssl = false
+  # num_cpus = 8
+  # memory = 8120
+  # adapter_type = "vmxnet3"
+}
 ```
 
 <!-- BEGIN_TF_DOCS -->

--- a/examples/vsphere-ova-vm-deployment/main.tf
+++ b/examples/vsphere-ova-vm-deployment/main.tf
@@ -20,8 +20,12 @@
 #####################################
 
 module "vsphere_ova_vm_deployment" {
-  # Here source points to the vsphere-ova-vm-deployment submodule in the modules folder. You can change the value to point it according to your usecase. 
-  source = "../../modules/vsphere-ova-vm-deployment"
+  # Here the source points to the a local instance of the submodule in the modules folder, if you have and instance of the modules folder locally.
+  # source = "../../modules/vsphere-ova-vm-deployment"
+
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/vsphere_pfmp_installation"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
 
   # Required
   vm_ova_path = "https://example.com/path/to/example.ova"

--- a/examples/vsphere-ova-vm-deployment/provider.tf
+++ b/examples/vsphere-ova-vm-deployment/provider.tf
@@ -7,11 +7,3 @@ terraform {
     }
   }
 }
-
-provider "vsphere" {
-  user                 = var.vsphere_user
-  password             = var.vsphere_password
-  vsphere_server       = var.vsphere_server
-  allow_unverified_ssl = var.allow_unverified_ssl
-  api_timeout          = 10
-}

--- a/examples/vsphere_pfmp_installation/README.md
+++ b/examples/vsphere_pfmp_installation/README.md
@@ -20,6 +20,45 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+## Example
+
+main.tf
+```hcl
+module "vsphere_pfmp_installation" {
+  # Here the source points to the a local instance of the submodule in the modules folder, if you have and instance of the modules folder locally.
+  # source = "../../modules/vsphere_pfmp_installation"
+
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/vsphere_pfmp_installation"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
+  # Required
+  # Ip address of the ntp server
+  ntp_ip = var.ntp_ip
+  # Ip address of installer node
+  installer_node_ip = var.installer_node_ip
+  # Ip address of node 1
+  node_1_ip = var.node_1_ip
+  # Ip address of node 2
+  node_2_ip = var.node_2_ip
+  # Ip address of node 3
+  node_3_ip = var.node_3_ip
+
+  # Optional values which if not set have default values
+  ## Username to all nodes default is 'delladmin'
+  # username = var.username  # default is 'delladmin'
+  ## Password to all nodes default is 'delladmin'
+  # password = var.password  
+  ## Local path where you are running terraform to the PFMP_Config.json
+  # local_path_to_pfmp_config = var.local_path_to_pfmp_config  # default is './PFMP_Config.json'
+  ## This is default on Powerflex 4.6 or greater
+  # destination_path_to_set_pfmp_config = var.destination_path_to_set_pfmp_config  # default is '/opt/dell/pfmp/PFMP_Installer/config/PFMP_Config.json'
+  ## To use this deployment as a co res deployment
+  # use_co_res = true
+}
+
+```
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/examples/vsphere_pfmp_installation/main.tf
+++ b/examples/vsphere_pfmp_installation/main.tf
@@ -20,8 +20,12 @@
 ##########################################
 
 module "vsphere_pfmp_installation" {
-  # Here source points to the vsphere_pfmp_installation submodule in the modules folder. You can change the value to point it according to your usecase. 
-  source = "../../modules/vsphere_pfmp_installation"
+  # Here the source points to the a local instance of the submodule in the modules folder, if you have and instance of the modules folder locally.
+  # source = "../../modules/vsphere_pfmp_installation"
+
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/vsphere_pfmp_installation"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
 
   # Required
   # Ip address of the ntp server

--- a/modules/azure_pfmp/providers.tf
+++ b/modules/azure_pfmp/providers.tf
@@ -29,9 +29,3 @@ terraform {
     }
   }
 }
-
-provider "azurerm" {
-  features {}
-
-  skip_provider_registration = true
-}

--- a/modules/sdc_host_esxi/README.md
+++ b/modules/sdc_host_esxi/README.md
@@ -15,6 +15,37 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+## Example main.tf
+main.tf
+```hcl
+module "sdc_host_esxi" {
+  
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/sdc_host_esxi"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
+  # Host information of the host which the SDC should be installed upone
+  remote_host={
+    user = "root" // SSH User
+    password = "password" // SSH Password
+  }
+
+  sdc_name = "terraform-sdc"// The name of the SDC will default to 'terraform-sdc'
+
+  ip="1.2.11.10" // IP of the EsXi Host which the SDC will be installed upon
+  
+  # SDC Package information
+  sdc_pkg = {
+    url = "https://example.com/sdc-4.5.0.263-esx8.x.zip" // SDC Package URL Download Location. For FTP Example like "ftp://username:password@ftpserver/path/to/file"
+    #local_dir = "/tmp" // If you want to download the package locally, put the path to download
+    pkg_name = "sdc-4.5.0.263-esx8.x.zip" // SDC downloaded package name
+    remote_pkg_name = "emc-sdc-package.zip" // Do not update this value
+    remote_dir = "/tmp" // Where the package will be downloaded on the ESXi Host
+    use_remote_path = true // Always set this to true
+  }
+}
+```
+
 # SDC Host Module for ESXi
 
 This Terraform module installs the SDC package on a remote ESXi host using the `powerflex_sdc_host` resource.

--- a/modules/sdc_host_esxi/main.tf
+++ b/modules/sdc_host_esxi/main.tf
@@ -114,7 +114,7 @@ resource powerflex_sdc_host sdc_local_path {
     guid         = random_uuid.sdc_guid.result
   }
    use_remote_path = local.use_remote_path
-   name = "sdc-${var.ip}"
+   name = var.sdc_name
    package_path = "${terraform_data.sdc_pkg_local[0].output.local_dir}/${terraform_data.sdc_pkg_local[0].output.pkg_name}"
    clusters_mdm_ips = var.mdm_ips
  }
@@ -134,7 +134,7 @@ resource powerflex_sdc_host sdc_local_path {
     guid         = random_uuid.sdc_guid.result
   }
    use_remote_path = local.use_remote_path
-   name = "sdc-${var.ip}"
+   name = var.sdc_name
    package_path = terraform_data.sdc_pkg_remote[0].output.sdc_pkg.pkg_name
    clusters_mdm_ips = var.mdm_ips
  }

--- a/modules/sdc_host_esxi/variables.tf
+++ b/modules/sdc_host_esxi/variables.tf
@@ -24,6 +24,12 @@ variable "ip" {
   description = "Stores the IP address of the remote Linux host."
 }
 
+variable "sdc_name" {
+  type        = string
+  description = "Stores the name which we want to designate to the SDC. Defaults to terraform-sdc."
+  default     = "terraform-sdc"
+}
+
 variable "remote_host" {
   description = "Stores the SSH credentials for connecting to the remote Linux host."
   type        = object({
@@ -40,6 +46,7 @@ variable "remote_host" {
 variable "mdm_ips" {
   description = "all the mdms (either primary,secondary or virtual ips) in a comma separated list by cluster if unset will use the mdms of the cluster set in the provider block eg. ['10.10.10.5,10.10.10.6', '10.10.10.7,10.10.10.8']"
   type        = list(string)
+  default = []
 }
 
 variable "sdc_pkg" {

--- a/modules/sdc_host_linux/README.md
+++ b/modules/sdc_host_linux/README.md
@@ -25,19 +25,101 @@ SDC Host module can only be used with terraform provider PowerFlex v1.6.0 and ab
 
 For SELinux configration, refer to "Configure the SDC (scini) driver for SELinux" section in PowerFlex Install/Upgrade guide.
 
-
+***Note**: VM should have the following packages **installed fio sshpass unzip yum-utils wget gcc make***
 
 ## Usage
 
+main.tf for Ubuntu
 ```hcl
-module "sdc_host" {
-  source = "./modules/sdc_host_linux"
+terraform {
+  required_providers {
+    powerflex = {
+      version = ">=1.6.0"
+      source  = "registry.terraform.io/dell/powerflex"
+      }
+    }
+}
 
-  versions = var.versions
-  ip = var.ip
-  remote_host = var.remote_host
-  scini = var.scini
-  sdc_pkg = var.sdc_pkg
+module "sdc_host" {
+
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/sdc_host_linux"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
+  remote_host = { // Stores the SSH credentials for connecting to the remote Linux host.
+      user = "root"
+      password = "password"
+  }
+
+
+  ip="1.2.11.4" //Stores the IP address of the remote Linux host.
+  versions={
+      pflex = "4.5.3000.118"
+      kernel = "5.15.0-1-generic"
+  }
+  scini = {
+      url = "" // leave as empty for autobuild = true
+      linux_distro = "Ubuntu"
+      autobuild_scini = true // allow to build scini on destination machine. This may not work on PowerFlex v3.X. Prerequisites here https://www.dell.com/support/kbdoc/en-us/000224134/how-to-on-demand-compilation-of-the-powerflex-sdc-driver 
+  }
+
+  sdc_pkg = {
+      url = "http://example.com/release/SIGNED/EMC-ScaleIO-sdc-4.5-3000.118.Ubuntu.22.04.x86_64.tar"
+      local_dir = "/tmp"
+      remote_pkg_name = "emc-sdc-package.tar" // Dont update this, It should be emc-sdc-package.tar
+      remote_dir = "/tmp" // temp directory on the SDC host
+      remote_file = "EMC-ScaleIO-sdc-4.5-3000.118.Ubuntu.22.04.x86_64.tar" // name of file once downloaded on to remote should match what is being downloaded from sdc_pkg
+      use_remote_path = true // Leave this as true
+      skip_download_sdc = false // Leave this as false
+  }
+  mdm_ips = [] // If only attaching to one cluster then leave as empty list [] and the default virtual ips will be picked up. If wanting to attach to more then one cluster, give the mdm ips in a fomat like so provider block eg. ['10.10.10.5,10.10.10.6', '10.10.10.7,10.10.10.8']
+}
+```
+
+main.tf for RHEL9
+```hcl
+terraform {
+  required_providers {
+    powerflex = {
+      version = ">=1.6.0"
+      source  = "registry.terraform.io/dell/powerflex"
+      }
+    }
+}
+
+module "sdc_host" {
+
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/sdc_host_linux"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
+  remote_host = { // Stores the SSH credentials for connecting to the remote Linux host.
+      user = "root"
+      password = "password"
+  }
+
+
+  ip="1.2.11.4" //Stores the IP address of the remote Linux host.
+  versions={
+      pflex = "4.5.3000.118"
+      kernel = "5.15.0-1-generic"
+  }
+  scini = {
+      url = "" // leave as empty for autobuild = true
+      linux_distro = "RHEL9"
+      autobuild_scini = true // allow to build scini on destination machine. This may not work on PowerFlex v3.X. Prerequisites here https://www.dell.com/support/kbdoc/en-us/000224134/how-to-on-demand-compilation-of-the-powerflex-sdc-driver 
+  }
+
+  sdc_pkg = {
+      url = "http://example.com/release/SIGNED/EMC-ScaleIO-sdc-4.5-3000.118.Ubuntu.22.04.x86_64.rpm"
+      local_dir = "/tmp"
+      remote_pkg_name = "emc-sdc-package.rpm" // Dont update this, It should be emc-sdc-package.rpm
+      remote_dir = "/tmp" // temp directory on the SDC host
+      remote_file = "EMC-ScaleIO-sdc-4.5-3000.118.Ubuntu.22.04.x86_64.rpm" // name of file once downloaded on to remote should match what is being downloaded from sdc_pkg
+      use_remote_path = true // Leave this as true
+      skip_download_sdc = false // Leave this as false
+  }
+  mdm_ips = [] // If only attaching to one cluster then leave as empty list [] and the default virtual ips will be picked up. If wanting to attach to more then one cluster, give the mdm ips in a fomat like so provider block eg. ['10.10.10.5,10.10.10.6', '10.10.10.7,10.10.10.8']
 }
 ```
 

--- a/modules/sdc_host_linux/main.tf
+++ b/modules/sdc_host_linux/main.tf
@@ -249,7 +249,7 @@ resource "terraform_data" "linux_scini_auto" {
    }
    os_family = "linux"
    use_remote_path = local.use_remote_path
-   name = "sdc-${var.ip}"
+   name = var.sdc_name
    package_path = "${terraform_data.sdc_pkg_local[0].output.local_dir}/${terraform_data.sdc_pkg_local[0].output.pkg_name}"
    clusters_mdm_ips = var.mdm_ips
  }
@@ -268,7 +268,7 @@ resource "terraform_data" "linux_scini_auto" {
    }
    os_family = "linux"
    use_remote_path = local.use_remote_path
-   name = "sdc-${var.ip}"
+   name = var.sdc_name
    package_path = terraform_data.sdc_pkg_remote[0].output.sdc_pkg.pkg_name
    clusters_mdm_ips = var.mdm_ips
  }

--- a/modules/sdc_host_linux/variables.tf
+++ b/modules/sdc_host_linux/variables.tf
@@ -24,6 +24,12 @@ variable "ip" {
   description = "Stores the IP address of the remote Linux host."
 }
 
+variable "sdc_name" {
+  type        = string
+  description = "Stores the name which we want to designate to the SDC. Defaults to terraform-sdc."
+  default     = "terraform-sdc"
+}
+
 variable "remote_host" {
   description = "Stores the SSH credentials for connecting to the remote Linux host."
   type        = object({
@@ -40,8 +46,8 @@ variable "remote_host" {
 variable "mdm_ips" {
   description = "all the mdms (either primary,secondary or virtual ips) in a comma separated list by cluster if unset will use the mdms of the cluster set in the provider block eg. ['10.10.10.5,10.10.10.6', '10.10.10.7,10.10.10.8']"
   type        = list(string)
+  default = []
 }
-
 
 variable "scini" {
  

--- a/modules/sdc_host_win/README.md
+++ b/modules/sdc_host_win/README.md
@@ -22,13 +22,35 @@ It downloads the package either on local machine or remote (Windows) machine and
 
 ## Usage
 
+main.tf
+
 ```hcl
+
+terraform {
+  required_providers {
+    powerflex = {
+      version = ">=1.6.0"
+      source  = "registry.terraform.io/dell/powerflex"
+      }
+    }
+}
+
 module "sdc_host_win" {
-  # Here source points to the sdc_host_win submodule in the modules folder. You can change the value to point it according to your usecase. 
-  source = "../../modules/sdc_host_win"
-  ip = var.ip
-  remote_host = var.remote_host
-  sdc_pkg = var.sdc_pkg
+  source = "dell/modules/powerflex//modules/sdc_host_win"
+  version = "x.x.x" //Grab the latest but for example 1.2.0
+  
+  sdc_name = "terraform-sdc"// The name of the SDC will default to 'terraform-sdc'
+  ip = "x.x.x.x" // Update to the IP of the VM which you want to install your SDC packages upon 
+  remote_host = {
+    user = "example-user" // Update to the username used to access the windows VM
+    password = "example-password" // Update to the password used ot access the windows VM 
+  }
+  sdc_pkg = {
+    url = "http://example.com/EMC-ScaleIO-sdc-4.6-x.x.msi" // URL to place where the sdc.msi file is hosted FTP Example: "ftp://username:password@ftpserver/path/to/EMC-ScaleIO-sdc-4.6-x.x.msi" # the name of the SDC package saved in local directory.
+    pkg_name = "EMC-ScaleIO-sdc-4.6-x.x.msi" 
+    local_dir = "/tmp" // Where the sdc_pkg will be downloaded
+    use_remote_path = false // download and use the SDC package on remote machine path (where SDC is going to be deployed)
+  }
 }
 ```
 

--- a/modules/sdc_host_win/main.tf
+++ b/modules/sdc_host_win/main.tf
@@ -89,7 +89,7 @@ resource powerflex_sdc_host sdc_local_path {
    }
    os_family = "windows"
    use_remote_path = local.use_remote_path
-   name = "sdc-${var.ip}"
+   name = var.sdc_name
    package_path = "${terraform_data.sdc_pkg_local[0].output.local_dir}/${terraform_data.sdc_pkg_local[0].output.pkg_name}"
    clusters_mdm_ips = var.mdm_ips
  }
@@ -104,7 +104,7 @@ resource powerflex_sdc_host sdc_local_path {
    }
    os_family = "windows"
    use_remote_path = local.use_remote_path
-   name = "sdc-${var.ip}"
+   name = var.sdc_name
    package_path = terraform_data.sdc_pkg_remote[0].output.sdc_pkg.pkg_name
    clusters_mdm_ips = var.mdm_ips
  }

--- a/modules/sdc_host_win/variables.tf
+++ b/modules/sdc_host_win/variables.tf
@@ -24,6 +24,12 @@ variable "ip" {
   description = "Stores the IP address of the remote Windows host."
 }
 
+variable "sdc_name" {
+  type        = string
+  description = "Stores the name which we want to designate to the SDC. Defaults to terraform-sdc."
+  default     = "terraform-sdc"
+}
+
 variable "remote_host" {
   description = "Stores the credentials for connecting to the remote Windows host."
   type        = object({
@@ -37,6 +43,7 @@ variable "remote_host" {
 variable "mdm_ips" {
   description = "all the mdms (either primary,secondary or virtual ips) in a comma separated list by cluster if unset will use the mdms of the cluster set in the provider block eg. ['10.10.10.5,10.10.10.6', '10.10.10.7,10.10.10.8']"
   type        = list(string)
+  default = []
 }
 
 variable "sdc_pkg" {

--- a/modules/user/README.md
+++ b/modules/user/README.md
@@ -18,6 +18,41 @@ limitations under the License.
 
 Manages user on a PowerFlex array. User resource can be used to create, update role and delete the user from the PowerFlex array. Once the user is created, it is mandatory to change the password when it's logged in for the first time. The intent of this user submodule is to change the password during it's first login.
 
+main.tf
+```hcl
+
+terraform {
+  required_providers {
+    powerflex = {
+      version = "1.2.0"
+      source  = "registry.terraform.io/dell/powerflex"
+    }
+    null = {  
+      source = "hashicorp/null"  
+      version = "3.2.1"  
+    }
+  }
+    
+}
+
+module "user_creation" {
+  # Here the source points to the a local instance of the submodule in the modules folder, if you have and instance of the modules folder locally. 
+  # source = "../../modules/user"
+
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/user"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
+  newUserName = "user"
+  userRole = "Monitor"
+  userPassword = "Password1234"
+  mdmUserName = "root"
+  mdmPassword = "Password"
+  mdmHost = "10.x.x.x"
+  newPassword = "Password123"
+}
+```
+
 ## Requirements
 
 | Name | Version |

--- a/modules/user/provider.tf
+++ b/modules/user/provider.tf
@@ -1,5 +1,3 @@
-
-
 terraform {
   required_providers {
     powerflex = {
@@ -13,12 +11,3 @@ terraform {
   }
     
 }
-provider "powerflex" {
-  username = var.username
-  password = var.password
-  endpoint = var.endpoint
-  insecure = true
-  timeout  = 120
-}
-
-provider "null" {}

--- a/modules/user/variables.tf
+++ b/modules/user/variables.tf
@@ -1,19 +1,4 @@
 
-variable "username" {
-  type        = string
-  description = "Stores the username of PowerFlex host."
-}
-
-variable "password" {
-  type        = string
-  description = "Stores the password of PowerFlex host."
-}
-
-variable "endpoint" {
-  type        = string
-  description = "Stores the endpoint of PowerFlex host. eg: https://10.1.1.1:443, here 443 is port where API requests are getting accepted"
-}
-
 variable "newUserName" {
   type        = string
   description = "Name of the new user."

--- a/modules/vsphere-ova-vm-deployment/README.md
+++ b/modules/vsphere-ova-vm-deployment/README.md
@@ -14,6 +14,36 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+main.tf
+```hcl
+module "vsphere_ova_vm_deployment" {
+  # Here the source points to the a local instance of the submodule in the modules folder, if you have and instance of the modules folder locally.
+  # source = "../../modules/vsphere-ova-vm-deployment"
+
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/vsphere_pfmp_installation"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
+  # Required
+  vm_ova_path = "https://example.com/path/to/example.ova"
+  vsphere_datacenter_name = "datacenter"
+  vsphere_datastore_name = "datastore"
+  vsphere_network_name = "network"
+  vsphere_host_name = "host-name"
+  vsphere_resource_pool_name = "resource-pool"
+
+
+  # Optional values which if not set have default values
+  # vm_name = "example-name"
+  # use_remote_path = false
+  # allow_unverified_ssl = false
+  # num_cpus = 8
+  # memory = 8120
+  # adapter_type = "vmxnet3"
+}
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/modules/vsphere_pfmp_installation/README.md
+++ b/modules/vsphere_pfmp_installation/README.md
@@ -1,3 +1,40 @@
+main.tf
+```hcl
+module "vsphere_pfmp_installation" {
+  # Here the source points to the a local instance of the submodule in the modules folder, if you have and instance of the modules folder locally.
+  # source = "../../modules/vsphere_pfmp_installation"
+
+  # Here is an example of a source that pulls from the registry
+  source  = "dell/modules/powerflex//modules/vsphere_pfmp_installation"
+  version = "x.x.x" // pull in the latest version like "1.2.0"
+
+  # Required
+  # Ip address of the ntp server
+  ntp_ip = var.ntp_ip
+  # Ip address of installer node
+  installer_node_ip = var.installer_node_ip
+  # Ip address of node 1
+  node_1_ip = var.node_1_ip
+  # Ip address of node 2
+  node_2_ip = var.node_2_ip
+  # Ip address of node 3
+  node_3_ip = var.node_3_ip
+
+  # Optional values which if not set have default values
+  ## Username to all nodes default is 'delladmin'
+  # username = var.username  # default is 'delladmin'
+  ## Password to all nodes default is 'delladmin'
+  # password = var.password  
+  ## Local path where you are running terraform to the PFMP_Config.json
+  # local_path_to_pfmp_config = var.local_path_to_pfmp_config  # default is './PFMP_Config.json'
+  ## This is default on Powerflex 4.6 or greater
+  # destination_path_to_set_pfmp_config = var.destination_path_to_set_pfmp_config  # default is '/opt/dell/pfmp/PFMP_Installer/config/PFMP_Config.json'
+  ## To use this deployment as a co res deployment
+  # use_co_res = true
+}
+
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 


### PR DESCRIPTION
## Module Example Updates

- Update READMEs, and Examples to give more indepth examples with comments about the fields.
- Allow user to set name in SDC modules
- Remove references to provider configs in the actual examples and modules. If they are set it causes issues when doing a terraform init from the registry source, does not affect when using local pathing for source. 